### PR TITLE
ROX-26765: Rename pipelineruns to enable on-push rerunning

### DIFF
--- a/.tekton/operator-index-ocp-v4-12-build.yaml
+++ b/.tekton/operator-index-ocp-v4-12-build.yaml
@@ -12,7 +12,7 @@ metadata:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-12
     appstudio.openshift.io/component: operator-index-ocp-v4-12
     pipelines.appstudio.openshift.io/type: build
-  name: operator-index-ocp-v4-12-build
+  name: operator-index-ocp-v4-12-on-push
   namespace: rh-acs-tenant
 
 spec:

--- a/.tekton/operator-index-ocp-v4-13-build.yaml
+++ b/.tekton/operator-index-ocp-v4-13-build.yaml
@@ -12,7 +12,7 @@ metadata:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-13
     appstudio.openshift.io/component: operator-index-ocp-v4-13
     pipelines.appstudio.openshift.io/type: build
-  name: operator-index-ocp-v4-13-build
+  name: operator-index-ocp-v4-13-on-push
   namespace: rh-acs-tenant
 
 spec:

--- a/.tekton/operator-index-ocp-v4-14-build.yaml
+++ b/.tekton/operator-index-ocp-v4-14-build.yaml
@@ -12,7 +12,7 @@ metadata:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-14
     appstudio.openshift.io/component: operator-index-ocp-v4-14
     pipelines.appstudio.openshift.io/type: build
-  name: operator-index-ocp-v4-14-build
+  name: operator-index-ocp-v4-14-on-push
   namespace: rh-acs-tenant
 
 spec:

--- a/.tekton/operator-index-ocp-v4-15-build.yaml
+++ b/.tekton/operator-index-ocp-v4-15-build.yaml
@@ -12,7 +12,7 @@ metadata:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-15
     appstudio.openshift.io/component: operator-index-ocp-v4-15
     pipelines.appstudio.openshift.io/type: build
-  name: operator-index-ocp-v4-15-build
+  name: operator-index-ocp-v4-15-on-push
   namespace: rh-acs-tenant
 
 spec:

--- a/.tekton/operator-index-ocp-v4-16-build.yaml
+++ b/.tekton/operator-index-ocp-v4-16-build.yaml
@@ -12,7 +12,7 @@ metadata:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-16
     appstudio.openshift.io/component: operator-index-ocp-v4-16
     pipelines.appstudio.openshift.io/type: build
-  name: operator-index-ocp-v4-16-build
+  name: operator-index-ocp-v4-16-on-push
   namespace: rh-acs-tenant
 
 spec:

--- a/.tekton/operator-index-ocp-v4-17-build.yaml
+++ b/.tekton/operator-index-ocp-v4-17-build.yaml
@@ -12,7 +12,7 @@ metadata:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-17
     appstudio.openshift.io/component: operator-index-ocp-v4-17
     pipelines.appstudio.openshift.io/type: build
-  name: operator-index-ocp-v4-17-build
+  name: operator-index-ocp-v4-17-on-push
   namespace: rh-acs-tenant
 
 spec:


### PR DESCRIPTION
Same as <https://github.com/stackrox/stackrox/pull/13147>, see <https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1730108686767279>. tl;dr: PipelineRuns must have `metadata.name` which consists of component-name + `-on-push` for us to be able to rerun Konflux CI for HEAD commit on `master` branch.