### PR TITLE
Use a matrix for multi-arch builds.

### DIFF
--- a/.tekton/operator-index-pipeline.yaml
+++ b/.tekton/operator-index-pipeline.yaml
@@ -116,7 +116,7 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-    description: List of platforms to build the container images on. The available
+    description: List of platforms to build the container images for. The available
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
@@ -185,12 +185,12 @@ spec:
     - name: basic-auth
       workspace: git-auth
 
-  - matrix:
+  - name: build-container
+    matrix:
       params:
       - name: PLATFORM
         value:
         - $(params.build-platforms)
-    name: build-container
     params:
     - name: IMAGE
       value: $(params.output-image-repo):$(params.output-image-tag)


### PR DESCRIPTION
Noticed this trick in [the docs](https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html). Let's do this to reduce duplication.

This seems to work as expected (index produced from 4 images) even though the graph does not show the dependency between the matrix and the index step:

![image](https://github.com/user-attachments/assets/6f7c8587-8e3c-439e-b28a-1f0539586ed9)
