### PR TITLE
ROX-27139: Rewrite downstream staging registry paths.

### DIFF
--- a/render-template.sh
+++ b/render-template.sh
@@ -51,12 +51,13 @@ jq --slurpfile channel channel-4.6.json '.entries += $channel
 ' catalog-template.json > "$tmp_template"
 echo >&2 "Running template rendering, this can take a few minutes..."
 
-# Render catalog and post-process result by rewriting the image repository:
+# Render catalog and post-process result by rewriting the image repository from either of
 #
 #     quay.io/rhacs-eng/stackrox-operator-bundle
 #     registry-proxy.engineering.redhat.com/rh-osbs/rhacs-operator-bundle
 #     brew.registry.redhat.io/rh-osbs/rhacs-operator-bundle
-#  -> registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle
+#
+#  to registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle
 "${OPM}" alpha render-template basic "$@" "${tmp_template}" \
   | jq 'walk(
       if type == "string" and (sub("@.*"; "") | in(


### PR DESCRIPTION
Tested by copying one of the existing `catalog.json` files aside, changing a couple of operator bundle images to the staging registries, piping it through the new `jq` program and diffing the output to the source:

```diff
@@ -12142,7 +12142,7 @@
   "schema": "olm.bundle",
   "name": "rhacs-operator.v4.7.0-163-g8f9cf23be2-fast",
   "package": "rhacs-operator",
-  "image": "registry-proxy.engineering.redhat.com/rh-osbs/rhacs-operator-bundle@sha256:e05042a079ef49d3198297a5203420d165f44f23f7baf9c5f1bfb6c345771418",
+  "image": "registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:e05042a079ef49d3198297a5203420d165f44f23f7baf9c5f1bfb6c345771418",
   "properties": [
     {
       "type": "olm.gvk",
@@ -12215,7 +12215,7 @@
   "relatedImages": [
     {
       "name": "",
-      "image": "quay.io/rhacs-eng/stackrox-operator-bundle@sha256:e05042a079ef49d3198297a5203420d165f44f23f7baf9c5f1bfb6c345771418"
+      "image": "registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:e05042a079ef49d3198297a5203420d165f44f23f7baf9c5f1bfb6c345771418"
     },
     {
       "name": "central_db",
```