### PR TITLE
fix: allow mintmaker to update tasks and images at any time

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,7 @@
     // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
     // that.
     // "after 3am and before 7am",
+    // Running at all times to allow Mintmaker to run more than once per day to catch up with rebases, etc.
     "at any time",
   ],
   // Tell Renovate not to update PRs when outside of schedule.
@@ -35,6 +36,7 @@
       // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
       // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
       // "after 3am and before 7am",
+      // Running at all times to allow Mintmaker to run more than once per day to catch up with rebases, etc.
       "at any time",
     ],
     "automerge": true,


### PR DESCRIPTION
Context: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1737458937330099?thread_ts=1737448841.545179&cid=C04PZ7H0VA8

TLDR:
* Hypothesis: Mintmaker runs only once per day and by the next iteration some other change in dependencies or this repo requires a rebase. Mintmaker never gets to the run where it would see checks and merge or open PR. 

This change will allow Mintmaker to run more than once per day and catch up with changes (get out of rebase cycle). 