### PR TITLE
ROX-27831: remove image expiration

### DIFF
--- a/.tekton/operator-index-ocp-v4-12-build.yaml
+++ b/.tekton/operator-index-ocp-v4-12-build.yaml
@@ -33,7 +33,7 @@ spec:
   - name: catalog-dir
     value: catalog-bundle-object
   - name: image-expires-after
-    value: 13w
+    value: ''
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-13-build.yaml
+++ b/.tekton/operator-index-ocp-v4-13-build.yaml
@@ -33,7 +33,7 @@ spec:
   - name: catalog-dir
     value: catalog-bundle-object
   - name: image-expires-after
-    value: 13w
+    value: ''
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-14-build.yaml
+++ b/.tekton/operator-index-ocp-v4-14-build.yaml
@@ -33,7 +33,7 @@ spec:
   - name: catalog-dir
     value: catalog-bundle-object
   - name: image-expires-after
-    value: 13w
+    value: ''
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-15-build.yaml
+++ b/.tekton/operator-index-ocp-v4-15-build.yaml
@@ -33,7 +33,7 @@ spec:
   - name: catalog-dir
     value: catalog-bundle-object
   - name: image-expires-after
-    value: 13w
+    value: ''
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-16-build.yaml
+++ b/.tekton/operator-index-ocp-v4-16-build.yaml
@@ -33,7 +33,7 @@ spec:
   - name: catalog-dir
     value: catalog-bundle-object
   - name: image-expires-after
-    value: 13w
+    value: ''
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-17-build.yaml
+++ b/.tekton/operator-index-ocp-v4-17-build.yaml
@@ -33,7 +33,7 @@ spec:
   - name: catalog-dir
     value: catalog-csv-metadata
   - name: image-expires-after
-    value: 13w
+    value: ''
 
   workspaces:
   - name: git-auth


### PR DESCRIPTION
It is required for images to not expire via Quay's `expire-after` label. 
There is another task that will implement a Garbage Collector: https://issues.redhat.com/browse/ROX-27836. 
