### PR TITLE
ROX-27676: Add a PipelineRun for OCP v4.18.

### DIFF
--- a/.tekton/operator-index-ocp-v4-18-build.yaml
+++ b/.tekton/operator-index-ocp-v4-18-build.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: base-image
-    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+    value: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
   - name: output-image-tag
     value: ocp-v4-18-{{revision}}-fast
   - name: catalog-dir

--- a/.tekton/operator-index-pipeline.yaml
+++ b/.tekton/operator-index-pipeline.yaml
@@ -109,7 +109,7 @@ spec:
     name: oci-artifact-expires-after
     type: string
   - default:
-    - linux/amd64
+    - linux/x86_64
     - linux/arm64
     - linux/ppc64le
     - linux/s390x


### PR DESCRIPTION
Also, authored by @msugakov (See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1738143148810919):

Switching x86 builds from VM to local actually helped to progress farther and find that it was the base image as the cause.