### PR TITLE
Switch base for 4.18 to brew image

### DIFF
--- a/.tekton/operator-index-ocp-v4-18-build.yaml
+++ b/.tekton/operator-index-ocp-v4-18-build.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: base-image
-    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+    value: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.18
   - name: output-image-tag
     value: ocp-v4-18-{{revision}}-fast
   - name: catalog-dir


### PR DESCRIPTION
See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1738143148810919

On top of https://github.com/stackrox/operator-index/pull/53, double-checking. I recommend merging https://github.com/stackrox/operator-index/pull/56 instead of this https://github.com/stackrox/operator-index/pull/57.