### PR TITLE
ROX-28121: Disable FBC image expiration

### DIFF
--- a/.tekton/operator-index-ocp-v4-12-build.yaml
+++ b/.tekton/operator-index-ocp-v4-12-build.yaml
@@ -32,8 +32,6 @@ spec:
     value: ocp-v4-12-{{revision}}-fast
   - name: catalog-dir
     value: catalog-bundle-object
-  - name: image-expires-after
-    value: 13w
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-13-build.yaml
+++ b/.tekton/operator-index-ocp-v4-13-build.yaml
@@ -32,8 +32,6 @@ spec:
     value: ocp-v4-13-{{revision}}-fast
   - name: catalog-dir
     value: catalog-bundle-object
-  - name: image-expires-after
-    value: 13w
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-14-build.yaml
+++ b/.tekton/operator-index-ocp-v4-14-build.yaml
@@ -32,8 +32,6 @@ spec:
     value: ocp-v4-14-{{revision}}-fast
   - name: catalog-dir
     value: catalog-bundle-object
-  - name: image-expires-after
-    value: 13w
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-15-build.yaml
+++ b/.tekton/operator-index-ocp-v4-15-build.yaml
@@ -32,8 +32,6 @@ spec:
     value: ocp-v4-15-{{revision}}-fast
   - name: catalog-dir
     value: catalog-bundle-object
-  - name: image-expires-after
-    value: 13w
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-16-build.yaml
+++ b/.tekton/operator-index-ocp-v4-16-build.yaml
@@ -32,8 +32,6 @@ spec:
     value: ocp-v4-16-{{revision}}-fast
   - name: catalog-dir
     value: catalog-bundle-object
-  - name: image-expires-after
-    value: 13w
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-17-build.yaml
+++ b/.tekton/operator-index-ocp-v4-17-build.yaml
@@ -32,8 +32,6 @@ spec:
     value: ocp-v4-17-{{revision}}-fast
   - name: catalog-dir
     value: catalog-csv-metadata
-  - name: image-expires-after
-    value: 13w
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v4-18-build.yaml
+++ b/.tekton/operator-index-ocp-v4-18-build.yaml
@@ -32,8 +32,6 @@ spec:
     value: ocp-v4-18-{{revision}}-fast
   - name: catalog-dir
     value: catalog-csv-metadata
-  - name: image-expires-after
-    value: 13w
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-pipeline.yaml
+++ b/.tekton/operator-index-pipeline.yaml
@@ -95,6 +95,10 @@ spec:
   - description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and
       weeks, respectively.
     name: image-expires-after
+    # Image expiry disabled because it sets quay.expires-after label on the image which fails Conforma at release time.
+    # A downside is that FBC images will stay in our Quay forever while certainly they become unneeded as time passes.
+    # TODO(ROX-27836): find a way to garbage-collect FBC images.
+    default: ''
   - default: "false"
     description: Build a source image.
     name: build-source-image


### PR DESCRIPTION
### Description

**tl;dr**: I suggest we simply drop `quay.expires-after` label (via blank `image-expires-after` parameter) for now and deal with the garbage later, in <https://issues.redhat.com/browse/ROX-27836>.

The suggestion <https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/4361> to allow `quay.expires-after` in any FBC image got rejected and so we have the following options.
1. Just don't add the setting anywhere. This PR.
2. Don't add the label in on-push builds but add it in on-pull-request ones. This is not simple because we have unified build files (I mean `operator-index-ocp-v4-*-build.yaml` files and [these CEL expressions](https://github.com/stackrox/operator-index/blob/8e38e12fa20d13ce382083f1601516c6b0f77315/.tekton/operator-index-ocp-v4-12-build.yaml#L12-L14)). We will have to introduce another copy of the file and split CEL expressions just for the sake of setting a different value for `image-expires-after` - that'll bring too much maintenance. Besides, we may not need to keep every on-push image forever but this option does not give the finer control.
3. Introduce Tom's [determine-image-expiration](https://github.com/stackrox/konflux-tasks/blob/420e3004f33e47ad3f603404cb277ede47fdd564/tasks/determine-image-expiration-task.yaml) task after minor adaptations. The problem is that we use out-of-the-box EC/Conforma policy for our FBCs. This policy does not allow our custom tasks (i.e. we only onboarded custom tasks to the policy around the product build). Neither other flavor of custom task would work for the same reason. CEL expressions [aren't supported for params](https://issues.redhat.com/browse/KONFLUX-6628).
4. Don't add the label for tagged builds. Similar maintenance pain as (2) due to duplicate files and also requires custom process/agreement when we create tags.
5. As an alternative to custom task and separate build files, use CEL expressions (or similar) to dynamically define the param's value. Unfortunately, this is not supported. There's a request for this though <https://issues.redhat.com/browse/KONFLUX-6628>.
6. Enable Konflux [registry_image_pruner](https://github.com/konflux-ci/image-controller/tree/main/config/registry_image_pruner). Won't work OOTB without the label on the image and the label is the thing we're trying to avoid. We could modify the pruner but that work is a project on its own (code seems easy but keeping the thing running continuously and healthy seems not).
7. Use ART's garbage collector. I have an action item to get in touch with them but from what I've heard it may not work with Konflux conventions.
8. Introduce a custom task which calls Quay API (example [here](https://github.com/quay/clair/blob/main/.github/actions/set-image-expiration/action.yml)) to set image expiration per pushed tag. We could create a custom IntegrationTestScenario for this so that the custom task does not cause Conforma violations but the problem is that we're not in control of all tags that are produced during the build process (example shared by Andrew [here](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1742491615906809?thread_ts=1738666715.941539&cid=C04PZ7H0VA8)). Without making calls for _each_ tag, the image data won't be collected.
9. Rely on Quay auto-pruning which may eventually come to quay.io. This is perfectly combinable with this PR and is part of my thinking how we'll address this.

Note, if we land this PR, this unblocks <https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/4696>.

### Validation

Pulled one of the images and inspected its labels to verify that `quay.expires-after` is absent.