### PR TITLE
ROX-27856: Add Slack failure notification and BigQuery metrics

### DIFF
--- a/.tekton/operator-index-pipeline.yaml
+++ b/.tekton/operator-index-pipeline.yaml
@@ -77,7 +77,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:cb26355b1f84fcebc056981b31ed6df64b96dfe26b82db27590f74e67e993f57
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d14158ccb8c613fb2bb1bebf86f29bbdde3418b27eb3b52352228da124d4b65f
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

- Added Slack notification for failures similar how we have in other pipelines.
- Added BigQuery metrics for successes and failures (task from https://github.com/stackrox/konflux-tasks/pull/45).

## Validation

For as much as I can see, there are no mentions of the metrics tasks in EC results which is good.
(https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs-operator-index-ocp-v4-17/pipelineruns/acs-operator-index-ocp-enterprise-contract-ocp-v4-17-vf7rq/security looked with eyes and searched for "post", "metric" and "bigq").

Glanced at the data in BigQuery for this PR. The data is there and looks reasonable.