### PR TITLE
ROX-27901: Update Renovate settings for FBCs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,15 +18,13 @@
   ],
   "timezone": "Etc/UTC",
   "schedule": [
+    // This controls when Renovate can create new branches and open PRs.
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
-    // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
-    // that.
-    // "after 3am and before 7am",
-    // Running at all times to allow Mintmaker to run more than once per day to catch up with rebases, etc.
-    "at any time",
+    // hours from Germany to US West Coast. This way, we limit the number of changes Renovate can merge to one per day.
+    "after 3am and before 7am",
   ],
-  // Tell Renovate to update PRs when outside of schedule.
+  // Tell Renovate that it can rebase and update its branches (and/or its PRs) at times outside the `schedule`.
   "updateNotScheduled": true,
   "tekton": {
     "includePaths": [
@@ -35,15 +33,17 @@
     "schedule": [
       // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
       // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
-      // "after 3am and before 7am",
-      // Running at all times to allow Mintmaker to run more than once per day to catch up with rebases, etc.
-      "at any time",
+      "after 3am and before 7am",
     ],
     "automerge": true,
     // PRs can't be actually automerged because we require approval from CODEOWNERS which Renovate can't bypass,
     // therefore we set automerge type to branch.
     "automergeType": "branch",
     "automergeStrategy": "squash",
+    // Tell Renovate that it can automerge branches at any time of the day.
+    "automergeSchedule": [
+      "at any time"
+    ],
   },
   "enabledManagers": [
     "tekton",


### PR DESCRIPTION
I noticed that Conforma does not like the usual tasks in our index pipelines.
That's because these tasks weren't updated by Mintmaker/Renovate, got old and now are outside of "still good" time window.

I can see MintMaker branches but nothing got merged for a while (see https://github.com/stackrox/operator-index/commits/master/). It's weird though that Renovate PRs did not get opened.

I modified branch protection rules for `master` in this `stackrox/operator-index` repo. Now instead of one legacy/classic rule (was here <https://github.com/stackrox/konflux-tasks/settings/branches>) there are two modern rules <https://github.com/stackrox/operator-index/settings/rules> similar to <https://github.com/stackrox/konflux-tasks/settings/rules>.

Here I suggest to apply similar changes as in https://github.com/stackrox/konflux-tasks/pull/39 and see how that would go in this repo (in `stackrox/konflux-tasks` I observe regular commits).

If this would not work well, we could switch MintMaker to always publish PRs and have auto-approval as in https://github.com/stackrox/konflux-tasks/pull/36.