### PR TITLE
ROX-28950: Mark latest channel as deprecated

### DIFF
--- a/catalog-bundle-object/rhacs-operator/catalog.json
+++ b/catalog-bundle-object/rhacs-operator/catalog.json
@@ -14863,3 +14863,16 @@
         }
     ]
 }
+{
+    "schema": "olm.deprecations",
+    "package": "rhacs-operator",
+    "entries": [
+        {
+            "reference": {
+                "schema": "olm.channel",
+                "name": "latest"
+            },
+            "message": "Channel \"latest\" is no longer supported.  Please switch to channel \"stable\".\n"
+        }
+    ]
+}

--- a/catalog-csv-metadata/rhacs-operator/catalog.json
+++ b/catalog-csv-metadata/rhacs-operator/catalog.json
@@ -126572,3 +126572,16 @@
         }
     ]
 }
+{
+    "schema": "olm.deprecations",
+    "package": "rhacs-operator",
+    "entries": [
+        {
+            "reference": {
+                "schema": "olm.channel",
+                "name": "latest"
+            },
+            "message": "Channel \"latest\" is no longer supported.  Please switch to channel \"stable\".\n"
+        }
+    ]
+}

--- a/catalog-template.yaml
+++ b/catalog-template.yaml
@@ -75,6 +75,14 @@ entries:
   name: latest
   package: rhacs-operator
   schema: olm.channel
+- schema: olm.deprecations
+  package: rhacs-operator
+  entries:
+  - reference:
+      schema: olm.channel
+      name: latest
+    message: |
+      Channel "latest" is no longer supported.  Please switch to channel "stable".
 - entries:
   - name: rhacs-operator.v3.62.0
     skipRange: '>= 3.61.0 < 3.62.0'


### PR DESCRIPTION
Baby steps, so that we still have change material in case we'll need more almost-no-op releases.