### PR TITLE
ROX-29479: Add mirrors for images in `release-` repos

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -7,43 +7,58 @@ metadata:
   name: quay-proxy
 spec:
   imageDigestMirrors:
+    # TODO: all mirrors without `release-` in the repo name can be removed after ROX-24620 is closed.
     - mirrors:
+        - quay.io/rhacs-eng/release-operator-bundle
         - quay.io/rhacs-eng/stackrox-operator-bundle
       source: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle
     - mirrors:
+        - quay.io/rhacs-eng/release-central-db
         - quay.io/rhacs-eng/central-db
       source: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-collector
         - quay.io/rhacs-eng/collector
       source: registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-collector
+        - quay.io/rhacs-eng/release-collector-slim
         - quay.io/rhacs-eng/collector
         - quay.io/rhacs-eng/collector-slim
       source: registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-main
         - quay.io/rhacs-eng/main
       source: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-operator
         - quay.io/rhacs-eng/stackrox-operator
       source: registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator
     - mirrors:
+        - quay.io/rhacs-eng/release-roxctl
         - quay.io/rhacs-eng/roxctl
       source: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-scanner-db
         - quay.io/rhacs-eng/scanner-db
       source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-scanner-db-slim
         - quay.io/rhacs-eng/scanner-db-slim
       source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-scanner
         - quay.io/rhacs-eng/scanner
       source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-scanner-slim
         - quay.io/rhacs-eng/scanner-slim
       source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-scanner-v4-db
         - quay.io/rhacs-eng/scanner-v4-db
       source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8
     - mirrors:
+        - quay.io/rhacs-eng/release-scanner-v4
         - quay.io/rhacs-eng/scanner-v4
       source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -8,57 +8,57 @@ metadata:
 spec:
   imageDigestMirrors:
     # TODO: all mirrors without `release-` in the repo name can be removed after ROX-24620 is closed.
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle
+      mirrors:
         - quay.io/rhacs-eng/release-operator-bundle
         - quay.io/rhacs-eng/stackrox-operator-bundle
-      source: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-central-db
         - quay.io/rhacs-eng/central-db
-      source: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-collector
         - quay.io/rhacs-eng/collector
-      source: registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-collector
         - quay.io/rhacs-eng/release-collector-slim
         - quay.io/rhacs-eng/collector
         - quay.io/rhacs-eng/collector-slim
-      source: registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-main
         - quay.io/rhacs-eng/main
-      source: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator
+      mirrors:
         - quay.io/rhacs-eng/release-operator
         - quay.io/rhacs-eng/stackrox-operator
-      source: registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-roxctl
         - quay.io/rhacs-eng/roxctl
-      source: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-scanner-db
         - quay.io/rhacs-eng/scanner-db
-      source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-scanner-db-slim
         - quay.io/rhacs-eng/scanner-db-slim
-      source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-scanner
         - quay.io/rhacs-eng/scanner
-      source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-scanner-slim
         - quay.io/rhacs-eng/scanner-slim
-      source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-scanner-v4-db
         - quay.io/rhacs-eng/scanner-v4-db
-      source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8
-    - mirrors:
+    - source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8
+      mirrors:
         - quay.io/rhacs-eng/release-scanner-v4
         - quay.io/rhacs-eng/scanner-v4
-      source: registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8


### PR DESCRIPTION
I realized it's needed for https://github.com/stackrox/operator-index/pull/103#discussion_r2126190893

### Validation

If CI is happy enough, it shouldn't make things worse.