### PR TITLE
Add tasks for release monitoring and getting build images from Konflux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,24 @@ $(OPM):
 import-legacy: $(OPM)
 	$(OPM) migrate registry.redhat.io/redhat/redhat-operator-index:v4.12 ./catalog-migrate
 	$(OPM) alpha convert-template basic --output yaml ./catalog-migrate/rhacs-operator/catalog.json > catalog-template.yaml
+
+.PHONY: get-build-images
+get-build-images:
+	@COMMIT=$$(git rev-parse HEAD); \
+	BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+	echo "Getting Konflux build images for revision \033[0;32m$$BRANCH\033[0m branch and commit \033[0;32m$$COMMIT\033[0m"; \
+	kubectl get pipelinerun -l pipelinesascode.tekton.dev/sha=$$COMMIT -o json | jq -r '\
+	if .items | length == 0 then \
+		"No pipelinerun CRs found for the current commit. It might be pruned alreadfy from the cluster. Use Konflux UI instead." \
+	else \
+		.items[]?.status.results[0].value \
+	end'
+
+
+.PHONY: monitor-release
+monitor-release:
+ifndef RELEASE_NAME_SUFFIX
+	$(error RELEASE_NAME_SUFFIX is not set. Please set it to the suffix of the release name you have generated and applied previously.)
+endif
+	@echo "Monitoring release $(RELEASE_NAME_SUFFIX)"
+	@kubectl get releases | grep "$(RELEASE_NAME_SUFFIX)"

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ get-build-images:
 		.items[]?.status.results[0].value \
 	end'
 
-
 .PHONY: monitor-release
 monitor-release:
 ifndef RELEASE_NAME_SUFFIX


### PR DESCRIPTION
Add two small commands for getting Konflux builds and monitoring the release. I think this might simplify interacting with Konflux UI and could prevent releaser engineers opening many tabs and monitor each of them individually.

*NOTE:* `pipelinerun` CR TTL is about 5 days. So getting build older than 5 days is an issue with this command and UI has to be used instead. I added a message which sugget to use UI if images are not found.

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/b2cc20d0-38fc-4dc3-9266-07a3ee69066b" />
