### PR TITLE
fix: Replace `oc apply` with `oc create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ make clean && make valid-catalogs
 1. Make sure you logged in to the Konflux cluster.
 2. Make sure you checked out the latest master branch: `git checkout master && git pull`
 3. Generate Release CR by running `./scripts/generate-releases.sh <staging|prod> > operator-index-release.yaml`. Use `staging` for test release and `prod` for production one.
-4. Apply generated Release CR to the cluster: `oc apply -f operator-index-release.yaml`
+4. Apply generated Release CR to the cluster: `oc create -f operator-index-release.yaml`
 5. Monitor release [using monitor release script](#monitoring-release). Release can have `Succeeded` or `Failed` statuses
 
 ## Getting built images for specific commit


### PR DESCRIPTION
Because we don't want to overwrite resources if they happen to already be on the cluster.