### PR TITLE
fix: Pin tags for OCP 4.12 and 4.13 images

### DIFF
--- a/.tekton/operator-index-ocp-v4-12-build.yaml
+++ b/.tekton/operator-index-ocp-v4-12-build.yaml
@@ -27,7 +27,10 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: base-image
-    value: registry.redhat.io/openshift4/ose-operator-registry:v4.12
+    # The tag is pinned here because it seems the last one to include architectures other than x86_64.
+    # See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1752509725098509
+    # The tag was found from https://catalog.redhat.com/software/containers/openshift4/ose-operator-registry/5cddd0bed70cc57c44b2e1f3/history
+    value: registry.redhat.io/openshift4/ose-operator-registry:v4.12-1746684240
   - name: output-image-tag
     value: ocp-v4-12-{{revision}}-fast
   - name: catalog-dir

--- a/.tekton/operator-index-ocp-v4-13-build.yaml
+++ b/.tekton/operator-index-ocp-v4-13-build.yaml
@@ -27,7 +27,8 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: base-image
-    value: registry.redhat.io/openshift4/ose-operator-registry:v4.13
+    # The tag is pinned for the same reason as for 4.12, see the comment there.
+    value: registry.redhat.io/openshift4/ose-operator-registry:v4.13-1747313384
   - name: output-image-tag
     value: ocp-v4-13-{{revision}}-fast
   - name: catalog-dir


### PR DESCRIPTION
This is to get images that have builds for ppc64le, s390x and arm64 platforms in addition to x86-64.

Related links:
- https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1752509725098509
- https://issues.redhat.com/browse/KFLUXSPRT-4161
- https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1752507254664739