### PR TITLE
chore: Switch 4.19's base image from brew to prod one

### DIFF
--- a/.tekton/operator-index-ocp-v4-19-build.yaml
+++ b/.tekton/operator-index-ocp-v4-19-build.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: base-image
-    value: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
   - name: output-image-tag
     value: ocp-v4-19-{{revision}}-fast
   - name: catalog-dir


### PR DESCRIPTION
Line 11 in https://spaces.redhat.com/display/StackRox/Add+support+for+new+OpenShift+version