### PR TITLE
chore: Stop triggering CI when switching PR from draft to ready

### DIFF
--- a/.tekton/checks.yaml
+++ b/.tekton/checks.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     # Arbitrarily chosen application. It just needs to exist, see https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1731696009187979
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-17

--- a/.tekton/operator-index-ocp-v4-12-build.yaml
+++ b/.tekton/operator-index-ocp-v4-12-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-12
     appstudio.openshift.io/component: operator-index-ocp-v4-12

--- a/.tekton/operator-index-ocp-v4-13-build.yaml
+++ b/.tekton/operator-index-ocp-v4-13-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-13
     appstudio.openshift.io/component: operator-index-ocp-v4-13

--- a/.tekton/operator-index-ocp-v4-14-build.yaml
+++ b/.tekton/operator-index-ocp-v4-14-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-14
     appstudio.openshift.io/component: operator-index-ocp-v4-14

--- a/.tekton/operator-index-ocp-v4-15-build.yaml
+++ b/.tekton/operator-index-ocp-v4-15-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-15
     appstudio.openshift.io/component: operator-index-ocp-v4-15

--- a/.tekton/operator-index-ocp-v4-16-build.yaml
+++ b/.tekton/operator-index-ocp-v4-16-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-16
     appstudio.openshift.io/component: operator-index-ocp-v4-16

--- a/.tekton/operator-index-ocp-v4-17-build.yaml
+++ b/.tekton/operator-index-ocp-v4-17-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-17
     appstudio.openshift.io/component: operator-index-ocp-v4-17

--- a/.tekton/operator-index-ocp-v4-18-build.yaml
+++ b/.tekton/operator-index-ocp-v4-18-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-18
     appstudio.openshift.io/component: operator-index-ocp-v4-18

--- a/.tekton/operator-index-ocp-v4-19-build.yaml
+++ b/.tekton/operator-index-ocp-v4-19-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
-      (event == "pull_request")
+      (event == "pull_request" && body.action != "ready_for_review")
   labels:
     appstudio.openshift.io/application: acs-operator-index-ocp-v4-19
     appstudio.openshift.io/component: operator-index-ocp-v4-19


### PR DESCRIPTION
It's already quite a thing to rebase PRs on this repo and then dealing with Konflux flakes.

Recently Konflux (or its Tekton layers) added CI triggering when PR is changed from draft to ready. https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1751634029809639?thread_ts=1751556512.356989&cid=C04PZ7H0VA8
Welcome new flakes.

This just disables such CI run so that if you had CI in draft mode, those results will stay.