### PR TITLE
ROX-30141: Use snapshots instead of pipelineruns for getting built images

### DIFF
--- a/scripts/generate-releases.sh
+++ b/scripts/generate-releases.sh
@@ -35,33 +35,28 @@ validate_environment() {
     fi
 }
 
-# Fetch the list of snapshots for provided commit and branch values. 
-# Make sure that only one the most recent snapshot per application is returned.
-get_snapshots() {
+# Fetch the list of snapshot names and associented application name for provided commit and branch values.
+get_snapshots_data() {
     local -r commit="$1"
     local -r branch="$2"
-    kubectl get -n rh-acs-tenant snapshot -l pac.test.appstudio.openshift.io/sha="${commit}" -o json | jq -r '
-        .items
-        | map(select((.metadata.annotations["pac.test.appstudio.openshift.io/source-branch"]=="'"${branch}"'") or (.metadata.annotations["pac.test.appstudio.openshift.io/source-branch"]=="refs/heads/'${branch}'")))
-        | sort_by(.spec.application)
-        | group_by(.spec.application)
-        | map(sort_by(.metadata.creationTimestamp) | last)
-        | .[]
+    snapshot_list="$(get_snapshots "$commit" "$branch")"
+    echo "$snapshot_list" | jq -r '
+        .[]
         | "\(.metadata.name)|\(.spec.application)"'
 }
 
 # Validate all expected Snapshots were found.
 validate_snapshots() {
     local -r commit="$1"
-    local -r snapshot_list="$2"
+    local -r snapshots_data="$2"
 
     local pipelines_count
     local snapshots_count
     pipelines_count="$(find ".tekton" -maxdepth 1 -type f -name "operator-index-ocp-*-build.yaml" | wc -l )"
-    snapshots_count="$(echo "$snapshot_list" | wc -l )"
+    snapshots_count="$(echo "$snapshots_data" | wc -l )"
 
     echo -e "Found the following snapshots for \033[0;32m$commit\033[0m commit:" >&2
-    echo "$snapshot_list" >&2
+    echo "$snapshots_data" >&2
 
     if [[ "$snapshots_count" -eq 0 ]]; then
         echo "ERROR: Could not find any Snapshots for the commit '${commit}'." >&2
@@ -77,7 +72,7 @@ validate_snapshots() {
 generate_release_resources() {
     local -r environment="$1"
     local -r commit="$2"
-    local -r snapshot_list="$3"
+    local -r snapshots_data="$3"
 
     local release_name
     local snapshot
@@ -131,7 +126,7 @@ generate_release_resources() {
           releasePlan: ${release_plan}
           snapshot: ${snapshot_copy}"
 
-    done <<< "$snapshot_list" > "${out_file}"
+    done <<< "$snapshots_data" > "${out_file}"
 
     echo "Staging the file for commit..."
     git add --verbose "${out_file}"
@@ -149,7 +144,7 @@ validate_branch "$branch"
 
 validate_environment "$environment" "$branch"
 
-snapshot_list=$(get_snapshots "$commit" "$branch")
-validate_snapshots "$commit" "$snapshot_list"
+snapshots_data=$(get_snapshots_data "$commit" "$branch")
+validate_snapshots "$commit" "$snapshots_data"
 
-generate_release_resources "$environment" "$commit" "$snapshot_list"
+generate_release_resources "$environment" "$commit" "$snapshots_data"

--- a/scripts/generate-releases.sh
+++ b/scripts/generate-releases.sh
@@ -40,9 +40,7 @@ get_snapshots_data() {
     local -r commit="$1"
     local -r branch="$2"
     snapshot_list="$(get_snapshots "$commit" "$branch")"
-    echo "$snapshot_list" | jq -r '
-        .[]
-        | "\(.metadata.name)|\(.spec.application)"'
+    echo "$snapshot_list" | jq -r '.[] | "\(.metadata.name)|\(.spec.application)"'
 }
 
 # Validate all expected Snapshots were found.

--- a/scripts/generate-releases.sh
+++ b/scripts/generate-releases.sh
@@ -140,7 +140,7 @@ commit="${2:-$(git rev-parse HEAD)}"
 commit="$(expand_commit "$commit")"
 
 branch="${3:-$(git rev-parse --abbrev-ref HEAD)}"
-validate_branch "$branch"
+validate_branch "$branch" "$commit"
 
 validate_environment "$environment" "$branch"
 

--- a/scripts/get-built-images.sh
+++ b/scripts/get-built-images.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
-if [[ "$#" -gt 1 || "${1:-}" == "--help" ]]; then
+if [[ "$#" -gt 2 || "${1:-}" == "--help" ]]; then
     echo "USAGE: ./$(basename "${BASH_SOURCE[0]}") [COMMIT]"
     echo ""
     echo "COMMIT - an optional 40 character-long SHA of the commit to pull built images only with this commit sha. Default: the latest commit in the current branch"
@@ -16,8 +16,15 @@ fi
 
 COMMIT="${1:-$(git rev-parse HEAD)}"
 COMMIT="$(expand_commit "$COMMIT")"
+BRANCH="${2:-$(git rev-parse --abbrev-ref HEAD)}"
 
 echo -e "Operator catalog images for commit \033[0;32m$COMMIT\033[0m:"
-result="$(kubectl get -n rh-acs-tenant snapshot -l pac.test.appstudio.openshift.io/sha="${COMMIT}" -o jsonpath='{range .items[*].spec.components[?(@.containerImage)]}{.name}: {.containerImage}{"\n"}{end}')"
-: "${result:?Error: No Snapshot CRs found for the commit. Use Konflux UI to get built images instead: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications.}"
-echo "$result"
+snapshot_list="$(get_snapshots "$COMMIT" "$BRANCH")"
+build_images="$(echo "$snapshot_list" | jq -r '
+  .[] 
+  | .spec.components[]?
+  | select(.containerImage)
+  |"\(.name): \(.containerImage)"'
+)"
+: "${build_images:?Error: No Snapshot CRs found for the commit. Use Konflux UI to get built images instead: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications.}"
+echo "$build_images"

--- a/scripts/get-built-images.sh
+++ b/scripts/get-built-images.sh
@@ -6,9 +6,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 source "$SCRIPT_DIR/helpers.sh"
 
 if [[ "$#" -gt 2 || "${1:-}" == "--help" ]]; then
-    echo "USAGE: ./$(basename "${BASH_SOURCE[0]}") [COMMIT]"
+    echo "USAGE: ./$(basename "${BASH_SOURCE[0]}") [COMMIT] [BRANCH]"
     echo ""
     echo "COMMIT - an optional 40 character-long SHA of the commit to pull built images only with this commit sha. Default: the latest commit in the current branch"
+    echo "BRANCH - an optional parameter to specify git branch name for filtering snapshots to get operator image references from. Default: currently checked out branch"
     echo ""
     echo "You must have your KUBECONFIG point to the Konflux cluster, see https://spaces.redhat.com/pages/viewpage.action?pageId=407312060#HowtoeverythingKonfluxforRHACS-GettingocCLItoworkwithKonflux."
     exit 1
@@ -17,6 +18,7 @@ fi
 COMMIT="${1:-$(git rev-parse HEAD)}"
 COMMIT="$(expand_commit "$COMMIT")"
 BRANCH="${2:-$(git rev-parse --abbrev-ref HEAD)}"
+validate_branch "$BRANCH" "$COMMIT"
 
 echo -e "Operator catalog images for commit \033[0;32m$COMMIT\033[0m:"
 snapshot_list="$(get_snapshots "$COMMIT" "$BRANCH")"

--- a/scripts/get-built-images.sh
+++ b/scripts/get-built-images.sh
@@ -14,9 +14,6 @@ fi
 COMMIT="${1:-$(git rev-parse HEAD)}"
 
 echo -e "Operator catalog images for commit \033[0;32m$COMMIT\033[0m:"
-kubectl -n rh-acs-tenant get pipelinerun.tekton.dev -l pipelinesascode.tekton.dev/sha="${COMMIT}" -o json | jq -r '
-    if .items | length == 0 then
-        "No PipelineRun CRs found for the current commit. It might be pruned already from the cluster. Use Konflux UI instead: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications"
-    else
-        .items[] | select(.status.conditions[]? | select(.type == "Succeeded" and .status == "True")) .status.results[]? | select(.name == "IMAGE_URL") | .value
-    end'
+result="$(kubectl get -n rh-acs-tenant snapshot -l pac.test.appstudio.openshift.io/sha="${COMMIT}" -o jsonpath='{range .items[*].spec.components[?(@.containerImage)]}{.name}: {.containerImage}{"\n"}{end}')"
+: "${result:?Error: No Snapshot CRs found for the commit. Use Konflux UI to get built images instead: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications.}"
+echo "$result"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,3 +13,16 @@ validate_branch() {
         return 1
     fi
 }
+
+# Fetch the list of snapshots for provided commit and branch values. 
+# Make sure that only one the most recent snapshot per application is returned.
+get_snapshots() {
+    local -r commit="$1"
+    local -r branch="$2"
+    kubectl get -n rh-acs-tenant snapshot -l pac.test.appstudio.openshift.io/sha="${commit}" -o json | jq -r '
+        .items
+        | map(select((.metadata.annotations["pac.test.appstudio.openshift.io/source-branch"]=="'"${branch}"'") or (.metadata.annotations["pac.test.appstudio.openshift.io/source-branch"]=="refs/heads/'${branch}'")))
+        | sort_by(.spec.application)
+        | group_by(.spec.application)
+        | map(sort_by(.metadata.creationTimestamp) | last)'
+}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,5 +1,7 @@
 # Expand commit to a full 40-character SHA. Returns the full commit SHA if successful, or an error message if not.
 expand_commit() {
+    git fetch --all
+    
     if ! git rev-parse --verify --end-of-options "$1^{commit}"; then
         echo "Cannot expand commit $1 to a full 40-character long SHA." >&2
         return 1
@@ -7,9 +9,17 @@ expand_commit() {
 }
 
 # Check if BRANCH is a valid known branch git branch for the remote repository, otherwise it's unlikely that any Snapshots will be found for it.
+# Also check if the provided commit belongs to the branch.
 validate_branch() {
+    git fetch --all
+
     if ! git ls-remote --exit-code --heads origin "$1" > /dev/null; then
         echo "ERROR: $1 branch does not exist on remote. Please check the branch name." >&2
+        return 1
+    fi
+
+    if ! git merge-base --is-ancestor "$2" "$1"; then
+        echo "ERROR: commit $2 does not belong to $1 branch. Please check the branch name." >&2
         return 1
     fi
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -29,7 +29,7 @@ validate_branch() {
 get_snapshots() {
     local -r commit="$1"
     local -r branch="$2"
-    kubectl get -n rh-acs-tenant snapshot -l pac.test.appstudio.openshift.io/sha="${commit}" -o json | jq -r '
+    kubectl get -n rh-acs-tenant snapshot -l pac.test.appstudio.openshift.io/sha="${commit}" -o json | jq '
         .items
         | map(select((.metadata.annotations["pac.test.appstudio.openshift.io/source-branch"]=="'"${branch}"'") or (.metadata.annotations["pac.test.appstudio.openshift.io/source-branch"]=="refs/heads/'${branch}'")))
         | sort_by(.spec.application)


### PR DESCRIPTION
We can no longer rely on pipelineruns CR to fetch image references. Snapshots are more reliable.
One caveat comparing Konflux UI is that snapshots contains images with digests and no tags, so I added "name" value as well to show which digest belongs to which OCP version.

OK example:
```
./scripts/get-built-images.sh 0980bc57029612d0c51484bff4dd00ff84d784eb master
Operator catalog images for commit 0980bc57029612d0c51484bff4dd00ff84d784eb:
operator-index-ocp-v4-12: quay.io/rhacs-eng/stackrox-operator-index@sha256:0280d4db28bbfde3b684f1f40922f95b7e00a5184d705dbee7670e1431a3a6e8
operator-index-ocp-v4-13: quay.io/rhacs-eng/stackrox-operator-index@sha256:f32511fdbe8fa71e072dab977730c03a5536498e9dfc05063fc9b018d7abb1dd
operator-index-ocp-v4-14: quay.io/rhacs-eng/stackrox-operator-index@sha256:a19e1ffd360ad5f3d1d93afc20e290a318bef65d5b02117860836c099686d6c8
operator-index-ocp-v4-15: quay.io/rhacs-eng/stackrox-operator-index@sha256:c9b3058e00045da4617c3f4c894b93ddc033237bf133d0ed29f99d8822c628fc
operator-index-ocp-v4-16: quay.io/rhacs-eng/stackrox-operator-index@sha256:92ff20dbf7a2441e6145f1eff15de779e695cabf3b886196586e2cd8369046fc
operator-index-ocp-v4-17: quay.io/rhacs-eng/stackrox-operator-index@sha256:69b90118e7b4c793c0a99bfd92ac20c4e1560f69c9b8bb13f27f06588334f087
operator-index-ocp-v4-18: quay.io/rhacs-eng/stackrox-operator-index@sha256:1e10597dda32a6ab7a6aa0e081fe2a56cdf81911135e50ba3573f0a9017cd010
operator-index-ocp-v4-19: quay.io/rhacs-eng/stackrox-operator-index@sha256:a855909c0204f0792b634f23a0b9182623e3e6ed8a9fbc069ed490ebd5a836c8
```

Error example:
```
./scripts/get-built-images.sh fd7c68e7ee5c76509ad0433696e702b89b786dfb master
Operator catalog images for commit fd7c68e7ee5c76509ad0433696e702b89b786dfb:
./scripts/get-built-images.sh: line 29: build_images: Error: No Snapshot CRs found for the commit. Use Konflux UI to get built images instead: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications.
```