### PR TITLE
ROX-30583: fix line counting

### DIFF
--- a/scripts/generate-releases.sh
+++ b/scripts/generate-releases.sh
@@ -50,8 +50,8 @@ validate_snapshots() {
 
     local pipelines_count
     local snapshots_count
-    pipelines_count="$(find ".tekton" -maxdepth 1 -type f -name "operator-index-ocp-*-build.yaml" | wc -l )"
-    snapshots_count="$(echo "$snapshots_data" | wc -l )"
+    pipelines_count="$(find ".tekton" -maxdepth 1 -type f -name "operator-index-ocp-*-build.yaml" | wc -l)"
+    snapshots_count="$(echo "$snapshots_data" | sed '/^$/d' | wc -l)"
 
     echo -e "Found the following snapshots for \033[0;32m$commit\033[0m commit:" >&2
     echo "$snapshots_data" >&2


### PR DESCRIPTION
Tested by running the script and with:
```
[operator-index]$ (echo a;echo b) | sed '/^$/d'| wc -l
2
[operator-index]$ echo a | sed '/^$/d'| wc -l
1
[operator-index]$ echo | sed '/^$/d'| wc -l
0
[operator-index]$ 
```