### PR TITLE
Release 4.9.6 prod FBC

### DIFF
--- a/release-history/20260506-prod-739bb92.yaml
+++ b/release-history/20260506-prod-739bb92.yaml
@@ -1,0 +1,504 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-12-20260506-163953-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-12
+    appstudio.openshift.io/component: operator-index-ocp-v4-12
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-12-20260506-163953-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-12
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:02974ae8ece93a56edf539bd73be78f298986e2b6217c7fbeb12c5fbb1b3102c
+      name: operator-index-ocp-v4-12
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-12-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-12
+  snapshot: acs-operator-index-ocp-v4-12-20260506-163953-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-14-20260506-164001-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-14
+    appstudio.openshift.io/component: operator-index-ocp-v4-14
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-14-20260506-164001-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-14
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:51ac376b9442fee1ffb635ced92bbfc4bd26367bb472fd2b0010664211e5b293
+      name: operator-index-ocp-v4-14
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-14-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-14
+  snapshot: acs-operator-index-ocp-v4-14-20260506-164001-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-16-20260506-163953-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-16
+    appstudio.openshift.io/component: operator-index-ocp-v4-16
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-16-20260506-163953-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-16
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:01462dba24a6a8a78deb7f2d2576612d0223401368b8b86cc0e7dc8efe5cc95f
+      name: operator-index-ocp-v4-16
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-16-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-16
+  snapshot: acs-operator-index-ocp-v4-16-20260506-163953-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-17-20260506-163953-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-17
+    appstudio.openshift.io/component: operator-index-ocp-v4-17
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-17-20260506-163953-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-17
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:b73d433e25662d5d64997a5175d3fee264a2b46d068ceb3629c7534db1833dd7
+      name: operator-index-ocp-v4-17
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-17-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-17
+  snapshot: acs-operator-index-ocp-v4-17-20260506-163953-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-18-20260506-164000-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-18
+    appstudio.openshift.io/component: operator-index-ocp-v4-18
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-18-20260506-164000-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-18
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:464bad5aa23e9c15f78304ec0840326b1463790a486d7a1c69ff03138e457ba9
+      name: operator-index-ocp-v4-18
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-18-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-18
+  snapshot: acs-operator-index-ocp-v4-18-20260506-164000-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-19-20260506-163953-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-19
+    appstudio.openshift.io/component: operator-index-ocp-v4-19
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-19-20260506-163953-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-19
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:204bccc66f76cbfef645af6bab43301fef61451f3c83aeffa6ecb8a65f9e4235
+      name: operator-index-ocp-v4-19
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-19-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-19
+  snapshot: acs-operator-index-ocp-v4-19-20260506-163953-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-20-20260506-164001-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-20
+    appstudio.openshift.io/component: operator-index-ocp-v4-20
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-20-20260506-164001-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-20
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:bf839a87141c479508d52445ae71efc49aa404fba5fda217e285dea728e1b19f
+      name: operator-index-ocp-v4-20
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-20-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-20
+  snapshot: acs-operator-index-ocp-v4-20-20260506-164001-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-21-20260506-163947-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-21
+    appstudio.openshift.io/component: operator-index-ocp-v4-21
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-21-20260506-163947-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-21
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:9ebf5719cc81a32ec3756575895cb2ef2276c286ed9ea6fac0b64d2d1b1c50d7
+      name: operator-index-ocp-v4-21
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-21-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-21
+  snapshot: acs-operator-index-ocp-v4-21-20260506-163947-20260506-prod-739b
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  annotations:
+    build.appstudio.redhat.com/pull_request_number: "379"
+    build.appstudio.redhat.com/target_branch: master
+    pac.test.appstudio.openshift.io/branch: master
+    pac.test.appstudio.openshift.io/sender: sachaudh
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Add 4.9.6 version (#379)
+
+      Add operator-bundle for ACS 4.9.6-rc.2 from Konflux snapshot
+      `acs-4-9--4-9-6-rc-2--20260428t163853z`.
+
+      Image:
+      `quay.io/rhacs-eng/release-operator-bundle@sha256:a1b09a8c8a2022e3c85cafcefe0533978627727bfa5e94de5f509c4755d7e697`
+
+      Will be updated to final `registry.redhat.io` image after Finish
+      Release.
+
+      ---------
+
+      Signed-off-by: Saif Chaudhry <schaudhr@redhat.com>
+    pac.test.appstudio.openshift.io/sha-url: https://github.com/stackrox/operator-index/commit/739bb927a37fc043614cd98bd5e895be2472c2e9
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/master
+    acs.redhat.com/original-snapshot-name: acs-operator-index-ocp-v4-22-20260506-163953-000
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-22
+    appstudio.openshift.io/component: operator-index-ocp-v4-22
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/sha: 739bb927a37fc043614cd98bd5e895be2472c2e9
+  name: acs-operator-index-ocp-v4-22-20260506-163953-20260506-prod-739b
+  namespace: rh-acs-tenant
+spec:
+  application: acs-operator-index-ocp-v4-22
+  artifacts: {}
+  componentGroup: ""
+  components:
+    - containerImage: quay.io/rhacs-eng/stackrox-operator-index@sha256:0e745837822a3fea6e44d759bb1047c50de46cdcef7e9da87e1e6afdbc3fdeef
+      name: operator-index-ocp-v4-22
+      source:
+        git:
+          revision: 739bb927a37fc043614cd98bd5e895be2472c2e9
+          url: https://github.com/stackrox/operator-index
+      version: ""
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: acs-operator-index-ocp-v4-22-20260506-prod-739bb92
+  namespace: rh-acs-tenant
+spec:
+  releasePlan: acs-operator-index-prod-ocp-v4-22
+  snapshot: acs-operator-index-ocp-v4-22-20260506-163953-20260506-prod-739b


### PR DESCRIPTION
Prod FBC release for RHACS 4.9.6.

OCP versions: v4-12 to v4-22.

Stage releases all succeeded.