### PR TITLE
fix(4.22) output-image-tag

### DIFF
--- a/.tekton/operator-index-ocp-v4-22-build.yaml
+++ b/.tekton/operator-index-ocp-v4-22-build.yaml
@@ -30,7 +30,7 @@ spec:
   - name: base-image
     value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
   - name: output-image-tag
-    value: ocp-v4-21-{{revision}}-fast
+    value: ocp-v4-22-{{revision}}-fast
   - name: catalog-dir
     value: catalog-csv-metadata
 


### PR DESCRIPTION
Noticed when looking at https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-operator-index-ocp-v4-22/pipelineruns/operator-index-ocp-v4-22-on-push-nvnz9