### PR TITLE
Add 4.11.1 version

### DIFF
--- a/bundles.yaml
+++ b/bundles.yaml
@@ -284,5 +284,5 @@ images:
     version: 4.10.4
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:09da338721670816180c98f7c24f2fae79971487b82bcfeca750d49b369ca0a6
     version: 4.11.0
-  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b
-    version: 4.11.1-rc.4
+  - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:2fe25a8ac9612f29a625969bb25d24938abb298e9a9e1e79fb3aa34c6a0e5f76
+    version: 4.11.1

--- a/bundles.yaml
+++ b/bundles.yaml
@@ -284,3 +284,5 @@ images:
     version: 4.10.4
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:09da338721670816180c98f7c24f2fae79971487b82bcfeca750d49b369ca0a6
     version: 4.11.0
+  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f
+    version: 4.11.1-rc.3

--- a/bundles.yaml
+++ b/bundles.yaml
@@ -284,5 +284,5 @@ images:
     version: 4.10.4
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:09da338721670816180c98f7c24f2fae79971487b82bcfeca750d49b369ca0a6
     version: 4.11.0
-  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f
-    version: 4.11.1-rc.3
+  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b
+    version: 4.11.1-rc.4

--- a/catalog-csv-metadata/rhacs-operator/catalog.json
+++ b/catalog-csv-metadata/rhacs-operator/catalog.json
@@ -2557,6 +2557,11 @@
             "name": "rhacs-operator.v4.11.0",
             "replaces": "rhacs-operator.v4.10.4",
             "skipRange": ">= 4.10.0 < 4.11.0"
+        },
+        {
+            "name": "rhacs-operator.v4.11.1-rc.3",
+            "replaces": "rhacs-operator.v4.11.0",
+            "skipRange": ">= 4.10.0 < 4.11.1-rc.3"
         }
     ]
 }
@@ -5216,6 +5221,11 @@
             "name": "rhacs-operator.v4.11.0",
             "replaces": "rhacs-operator.v4.10.4",
             "skipRange": ">= 4.10.0 < 4.11.0"
+        },
+        {
+            "name": "rhacs-operator.v4.11.1-rc.3",
+            "replaces": "rhacs-operator.v4.11.0",
+            "skipRange": ">= 4.10.0 < 4.11.1-rc.3"
         }
     ]
 }
@@ -72990,6 +73000,2037 @@
         {
             "name": "scanner_v4",
             "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel9@sha256:6a5924702546f59d8c065197767b3ef11e0bffb10c34db2763bcd3cef06683e5"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "rhacs-operator.v4.11.1-rc.3",
+    "package": "rhacs-operator",
+    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "config.stackrox.io",
+                "kind": "SecurityPolicy",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "platform.stackrox.io",
+                "kind": "Central",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "platform.stackrox.io",
+                "kind": "SecuredCluster",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "rhacs-operator",
+                "version": "4.11.1-rc.3"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"Central\",\n    \"metadata\": {\n      \"name\": \"stackrox-central-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"central\": {\n        \"exposure\": {\n          \"route\": {\n            \"enabled\": true\n          }\n        }\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"SecuredCluster\",\n    \"metadata\": {\n      \"name\": \"stackrox-secured-cluster-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"clusterName\": \"my-cluster\"\n    }\n  }\n]",
+                    "capabilities": "Seamless Upgrades",
+                    "categories": "Security",
+                    "console.openshift.io/plugins": "[\"advanced-cluster-security\"]",
+                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:18cdd2eff9f9e055e25607304c289942b390c98abf170f44e1adf91929fb1da7",
+                    "createdAt": "2026-07-03T13:59:16Z",
+                    "description": "Red Hat Advanced Cluster Security (RHACS) operator provisions the services necessary to secure each of your OpenShift and Kubernetes clusters.",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "true",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "olm.skipRange": ">= 4.10.0 < 4.11.1-rc.3",
+                    "operatorframework.io/suggested-namespace": "rhacs-operator",
+                    "operators.openshift.io/infrastructure-features": "[\"disconnected\", \"proxy-aware\"]",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Platform Plus\", \"Red Hat Advanced Cluster Security\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-unknown",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
+                    "support": "Red Hat"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "centrals.platform.stackrox.io",
+                            "version": "v1alpha1",
+                            "kind": "Central",
+                            "displayName": "Central",
+                            "description": "Central is the configuration template for the central services. This includes the API server, persistent storage,\nand the web UI, as well as the image scanner.",
+                            "resources": [
+                                {
+                                    "name": "",
+                                    "kind": "Deployment",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Route",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Secret",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Service",
+                                    "version": "v1"
+                                }
+                            ],
+                            "statusDescriptors": [
+                                {
+                                    "path": "central.adminPassword.info",
+                                    "displayName": "Admin Credentials Info",
+                                    "description": "Info stores information on how to obtain the admin password."
+                                },
+                                {
+                                    "path": "productVersion",
+                                    "displayName": "Product Version",
+                                    "description": "The deployed version of the product."
+                                },
+                                {
+                                    "path": "central",
+                                    "displayName": "Central"
+                                },
+                                {
+                                    "path": "central.adminPassword.adminPasswordSecretReference",
+                                    "displayName": "Admin Password Secret Reference",
+                                    "description": "AdminPasswordSecretReference contains reference for the admin password",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "observedGeneration",
+                                    "displayName": "Observed Generation",
+                                    "description": "ObservedGeneration is the generation most recently observed by the controller."
+                                }
+                            ],
+                            "specDescriptors": [
+                                {
+                                    "path": "central",
+                                    "displayName": "Central Component Settings",
+                                    "description": "Settings for the Central component, which is responsible for all user interaction."
+                                },
+                                {
+                                    "path": "scanner",
+                                    "displayName": "Scanner Component Settings",
+                                    "description": "Settings for the Scanner component, which is responsible for vulnerability scanning of container\nimages."
+                                },
+                                {
+                                    "path": "scannerV4",
+                                    "displayName": "Scanner V4 Component Settings",
+                                    "description": "Settings for the Scanner V4 component, which can run in addition to the previously existing Scanner components"
+                                },
+                                {
+                                    "path": "egress",
+                                    "displayName": "Egress",
+                                    "description": "Settings related to outgoing network traffic."
+                                },
+                                {
+                                    "path": "tls",
+                                    "displayName": "TLS",
+                                    "description": "Settings related to Transport Layer Security, such as Certificate Authorities."
+                                },
+                                {
+                                    "path": "imagePullSecrets",
+                                    "displayName": "Image Pull Secrets",
+                                    "description": "Additional image pull secrets to be taken into account for pulling images.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "customize",
+                                    "displayName": "Customizations",
+                                    "description": "Customizations to apply on all Central Services components.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "overlays",
+                                    "displayName": "Overlays",
+                                    "description": "Overlays",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Monitoring configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "network",
+                                    "displayName": "Network",
+                                    "description": "Network configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "configAsCode",
+                                    "displayName": "Config-as-Code",
+                                    "description": "Config-as-Code configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "misc",
+                                    "displayName": "Miscellaneous",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nMiscellaneous settings.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.adminPasswordSecret",
+                                    "displayName": "Administrator Password",
+                                    "description": "Specify a secret that contains the administrator password in the \"password\" data item.\nIf omitted, the operator will auto-generate a password and store it in the \"password\" item\nin the \"central-htpasswd\" secret."
+                                },
+                                {
+                                    "path": "central.exposure",
+                                    "displayName": "Exposure",
+                                    "description": "Here you can configure if you want to expose central through a node port, a load balancer, or an OpenShift\nroute."
+                                },
+                                {
+                                    "path": "central.defaultTLSSecret",
+                                    "displayName": "User-facing TLS certificate secret",
+                                    "description": "By default, Central will only serve an internal TLS certificate, which means that you will\nneed to handle TLS termination at the ingress or load balancer level.\nIf you want to terminate TLS in Central and serve a custom server certificate, you can specify\na secret containing the certificate and private key here."
+                                },
+                                {
+                                    "path": "central.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Central. The monitoring endpoint\nallows other services to collect metrics from Central, provided in\nPrometheus compatible format."
+                                },
+                                {
+                                    "path": "central.db",
+                                    "displayName": "Central DB Settings",
+                                    "description": "Settings for Central DB, which is responsible for data persistence."
+                                },
+                                {
+                                    "path": "central.telemetry",
+                                    "displayName": "Telemetry",
+                                    "description": "Configures telemetry settings for Central. If enabled, Central transmits telemetry and diagnostic\ndata to a remote storage backend.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration",
+                                    "displayName": "Declarative Configuration",
+                                    "description": "Configures resources within Central in a declarative manner.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.notifierSecretsEncryption",
+                                    "displayName": "Notifier Secrets Encryption",
+                                    "description": "Configures the encryption of notifier secrets stored in the Central DB.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "central.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "central.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "central.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "central.adminPasswordGenerationDisabled",
+                                    "displayName": "Admin Password Generation Disabled",
+                                    "description": "Disable admin password generation. Do not use this for first-time installations,\nas you will have no way to perform initial setup and configuration of alternative authentication methods.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Unused field. This field exists solely for backward compatibility starting from version v4.6.0.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.adminPasswordSecret.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.passwordSecret",
+                                    "displayName": "Administrator Password",
+                                    "description": "Specify a secret that contains the password in the \"password\" data item. This can only be used when\nspecifying a connection string manually.\nWhen omitted, the operator will auto-generate a DB password and store it in the \"password\" item\nin the \"central-db-password\" secret."
+                                },
+                                {
+                                    "path": "central.db.connectionString",
+                                    "displayName": "Connection String",
+                                    "description": "Specify a connection string that corresponds to a database managed elsewhere. If set, the operator will not manage the Central DB.\nWhen using this option, you must explicitly set a password secret; automatically generating a password will not\nbe supported."
+                                },
+                                {
+                                    "path": "central.db.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Configures how Central DB should store its persistent data. You can choose between using a persistent\nvolume claim (recommended default), and a host path."
+                                },
+                                {
+                                    "path": "central.db.configOverride",
+                                    "displayName": "Config map that will override postgresql.conf and pg_hba.conf",
+                                    "description": "Config map containing postgresql.conf and pg_hba.conf that will be used if modifications need to be applied."
+                                },
+                                {
+                                    "path": "central.db.connectionPoolSize",
+                                    "displayName": "Database Connection Pool Size Settings",
+                                    "description": "Configures the database connection pool size."
+                                },
+                                {
+                                    "path": "central.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "central.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "central.db.isEnabled",
+                                    "displayName": "Is Enabled",
+                                    "description": "Obsolete field.\nThis field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.configOverride.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced config map.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:ConfigMap"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.connectionPoolSize.maxConnections",
+                                    "displayName": "Maximum Connections",
+                                    "description": "Maximum number of connections in the connection pool.\nThe default is: 90."
+                                },
+                                {
+                                    "path": "central.db.connectionPoolSize.minConnections",
+                                    "displayName": "Minimum Connections",
+                                    "description": "Minimum number of connections in the connection pool.\nThe default is: 10."
+                                },
+                                {
+                                    "path": "central.db.passwordSecret.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent volume claim",
+                                    "description": "Uses a Kubernetes persistent volume claim (PVC) to manage the storage location of persistent data.\nRecommended for most users."
+                                },
+                                {
+                                    "path": "central.db.persistence.hostPath",
+                                    "displayName": "Host path",
+                                    "description": "Stores persistent data in a directory on the host. This is not recommended, and should only\nbe used together with a node selector (only available in YAML view)."
+                                },
+                                {
+                                    "path": "central.db.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be\ncreated.\nThe default is: central-db."
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "The size of the persistent volume when created through the claim. If a claim was automatically created,\nthis can be used after the initial deployment to resize (grow) the volume (only supported by some\nstorage class controllers).",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:text"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class",
+                                    "description": "The name of the storage class to use for the PVC. If your cluster is not configured with a default storage\nclass, you must select a value here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:StorageClass"
+                                    ]
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.configMaps",
+                                    "displayName": "Config maps containing declarative configuration",
+                                    "description": "List of config maps containing declarative configuration."
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.secrets",
+                                    "displayName": "Secrets containing declarative configuration",
+                                    "description": "List of secrets containing declarative configuration."
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.configMaps[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced config map.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:ConfigMap"
+                                    ]
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.secrets[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.defaultTLSSecret.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.route",
+                                    "displayName": "Route",
+                                    "description": "Expose Central through an OpenShift route."
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer",
+                                    "displayName": "Load Balancer",
+                                    "description": "Expose Central through a load balancer service."
+                                },
+                                {
+                                    "path": "central.exposure.nodePort",
+                                    "displayName": "Node Port",
+                                    "description": "Expose Central through a node port."
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer.port",
+                                    "displayName": "Port",
+                                    "description": "The default is: 443.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.exposure.loadBalancer.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer.ip",
+                                    "displayName": "IP",
+                                    "description": "If you have a static IP address reserved for your load balancer, you can enter it here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.exposure.loadBalancer.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.nodePort.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.nodePort.port",
+                                    "displayName": "Port",
+                                    "description": "Use this to specify an explicit node port. Most users should leave this empty.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.exposure.nodePort.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.route.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Expose Central with a passthrough route.\nThe default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.route.host",
+                                    "displayName": "Host",
+                                    "description": "Specify a custom hostname for the Central route.\nIf unspecified, an appropriate default value will be automatically chosen by the OpenShift route operator."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt",
+                                    "displayName": "Re-Encrypt Route",
+                                    "description": "Set up a Central route with reencrypt TLS termination.\nFor reencrypt routes, the request is terminated on the OpenShift router with a custom certificate.\nThe request is then reencrypted by the OpenShift router and sent to Central.\n[user] --TLS--> [OpenShift router] --TLS--> [Central]"
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Expose Central with a reencrypt route.\nShould not be used for sensor communication.\nThe default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.host",
+                                    "displayName": "Host",
+                                    "description": "Specify a custom hostname for the Central reencrypt route.\nIf unspecified, an appropriate default value will be automatically chosen by the OpenShift route operator."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls",
+                                    "displayName": "TLS Settings",
+                                    "description": "TLS settings for exposing Central via a reencrypt Route."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.caCertificate",
+                                    "displayName": "CA Certificate",
+                                    "description": "The PEM encoded certificate chain that may be used to establish a complete chain of trust.\nDefaults to the OpenShift certificate authority."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.certificate",
+                                    "displayName": "Certificate",
+                                    "description": "The PEM encoded certificate that is served on the route. Must be a single serving\ncertificate instead of a certificate chain.\nDefaults to a certificate signed by the OpenShift certificate authority."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.destinationCACertificate",
+                                    "displayName": "Destination CA Certificate",
+                                    "description": "The CA certificate of the final destination, i.e. of Central.\nUsed by the OpenShift router for health checks on the secure connection.\nDefaults to the Central certificate authority."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.key",
+                                    "displayName": "Private Key",
+                                    "description": "The PEM encoded private key of the certificate that is served on the route.\nDefaults to a certificate signed by the OpenShift certificate authority."
+                                },
+                                {
+                                    "path": "central.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "central.notifierSecretsEncryption.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Enables the encryption of notifier secrets stored in the Central DB.\nThe default is: false."
+                                },
+                                {
+                                    "path": "central.persistence.hostPath",
+                                    "displayName": "Host Path",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent Volume Claim",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class Name",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.telemetry.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Specifies whether Telemetry is enabled.\nThe default is: true.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+                                    ]
+                                },
+                                {
+                                    "path": "central.telemetry.storage",
+                                    "displayName": "Storage",
+                                    "description": "Defines the telemetry storage backend for Central.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.telemetry.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.telemetry.storage.endpoint",
+                                    "displayName": "Endpoint",
+                                    "description": "Storage API endpoint."
+                                },
+                                {
+                                    "path": "central.telemetry.storage.key",
+                                    "displayName": "Key",
+                                    "description": "Storage API key. If not set, telemetry is disabled."
+                                },
+                                {
+                                    "path": "configAsCode.configAsCodeComponent",
+                                    "displayName": "Config as Code component",
+                                    "description": "If you want to deploy the Config as Code component, set this to \"Enabled\"\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "configAsCode.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "configAsCode.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "configAsCode.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "configAsCode.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "customize.labels",
+                                    "displayName": "Labels",
+                                    "description": "Custom labels to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.annotations",
+                                    "displayName": "Annotations",
+                                    "description": "Custom annotations to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.envVars",
+                                    "displayName": "Environment Variables",
+                                    "description": "Custom environment variables to set on managed pods' containers."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults",
+                                    "displayName": "Deployment Defaults",
+                                    "description": "Global nodeSelector and tolerations for Deployment-based components. DaemonSets (Collector) are not affected.\nComponent-level nodeSelector and tolerations settings override these defaults on a field-by-field basis."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults.pinToNodes",
+                                    "displayName": "Pin To Nodes",
+                                    "description": "Pin all Deployment-based components to specific node types. This is a convenience setting\nthat automatically configures both nodeSelector and tolerations with predefined values.\nUse this for common scenarios like running on OpenShift infrastructure nodes.\nFor custom node selection, use the explicit nodeSelector and tolerations fields instead.\nCannot be used together with nodeSelector or tolerations fields.\nThe default is: None."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "Default nodeSelector applied to all Deployment-based components. Use this for custom node\nselection criteria.\nCannot be used together with pinToNodes."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "Default tolerations applied to all Deployment-based components. Use this when your target\nnodes have custom taints that pods must tolerate.\nCannot be used together with pinToNodes."
+                                },
+                                {
+                                    "path": "egress.connectivityPolicy",
+                                    "displayName": "Connectivity Policy",
+                                    "description": "Configures whether Red Hat Advanced Cluster Security should run in online or offline (disconnected) mode.\nIn offline mode, automatic updates of vulnerability definitions and kernel modules are disabled.\nThe default is: Online."
+                                },
+                                {
+                                    "path": "imagePullSecrets[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "misc.createSCCs",
+                                    "displayName": "Create SecurityContextConstraints for Operand",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nSet this to true to have the operator create SecurityContextConstraints (SCCs) for the operands. This\nisn't usually needed, and may interfere with other workloads.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring.openshift.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: true.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+                                    ]
+                                },
+                                {
+                                    "path": "network.policies",
+                                    "displayName": "Network Policies",
+                                    "description": "To provide security at the network level, the ACS Operator creates NetworkPolicy resources by default. If you want to manage your own NetworkPolicy objects then set this to \"Disabled\".\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "overlays[0].apiVersion",
+                                    "displayName": "API Version",
+                                    "description": "Resource API version."
+                                },
+                                {
+                                    "path": "overlays[0].kind",
+                                    "displayName": "Kind",
+                                    "description": "Resource kind."
+                                },
+                                {
+                                    "path": "overlays[0].name",
+                                    "displayName": "Name",
+                                    "description": "Name of resource."
+                                },
+                                {
+                                    "path": "overlays[0].optional",
+                                    "displayName": "Optional",
+                                    "description": "Optional marks the overlay as optional.\nWhen Optional is true, and the specified resource does not exist in the output manifests, the overlay will be skipped, and a warning will be logged.\nWhen Optional is false, and the specified resource does not exist in the output manifests, an error will be thrown."
+                                },
+                                {
+                                    "path": "overlays[0].patches",
+                                    "displayName": "Patches",
+                                    "description": "List of patches to apply to resource."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].path",
+                                    "displayName": "Path",
+                                    "description": "Path of the form a.[key1:value1].b.[:value2]\nWhere [key1:value1] is a selector for a key-value pair to identify a list element and [:value] is a value\nselector to identify a list element in a leaf list.\nAll path intermediate nodes must exist."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].value",
+                                    "displayName": "Value",
+                                    "description": "Value to add, delete or replace.\nFor add, the path should be a new leaf.\nFor delete, value should be unset.\nFor replace, path should reference an existing node.\nAll values are strings but are converted into appropriate type based on schema."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].verbatim",
+                                    "displayName": "Verbatim",
+                                    "description": "Verbatim value to add, delete or replace.\nSame as Value, but the content is not interpreted as YAML and is treated as a literal string instead.\nAt least one of Value and Verbatim must be empty."
+                                },
+                                {
+                                    "path": "scanner.scannerComponent",
+                                    "displayName": "Scanner Component",
+                                    "description": "If you do not want to deploy the Red Hat Advanced Cluster Security Scanner, you can disable it here\n(not recommended). By default, the scanner is enabled.\nIf you do so, all the settings in this section will have no effect."
+                                },
+                                {
+                                    "path": "scanner.analyzer",
+                                    "displayName": "Analyzer",
+                                    "description": "Settings pertaining to the analyzer deployment, such as for autoscaling.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the database used by the Red Hat Advanced Cluster Security Scanner.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Scanner. The monitoring endpoint\nallows other services to collect metrics from Scanner, provided in\nPrometheus compatible format."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of analyzer replicas and autoscaling."
+                                },
+                                {
+                                    "path": "scanner.analyzer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scanner.analyzer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scanner.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scanner.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "scannerV4.scannerComponent",
+                                    "displayName": "Scanner V4 component",
+                                    "description": "Can be specified as \"Enabled\" or \"Disabled\".\nIf this field is not specified, the following defaulting takes place:\n* for upgrades to 4.8 from previous releases, the default is: Disabled;\n* for new installations starting with ACS 4.8, the default is: Enabled."
+                                },
+                                {
+                                    "path": "scannerV4.indexer",
+                                    "displayName": "Indexer",
+                                    "description": "Settings pertaining to the indexer deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher",
+                                    "displayName": "Matcher",
+                                    "description": "Settings pertaining to the matcher deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the DB deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Scanner V4. The monitoring endpoint\nallows other services to collect metrics from Scanner V4, provided in\nPrometheus compatible format.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Configures how Scanner V4 should store its persistent data.\nYou can use a persistent volume claim (the recommended default), a host path,\nor an emptyDir volume if Scanner V4 is running on a secured cluster without default StorageClass."
+                                },
+                                {
+                                    "path": "scannerV4.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scannerV4.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent volume claim",
+                                    "description": "Uses a Kubernetes persistent volume claim (PVC) to manage the storage location of persistent data.\nRecommended for most users."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath",
+                                    "displayName": "Host path",
+                                    "description": "Stores persistent data in a directory on the host. This is not recommended, and should only\nbe used together with a node selector (only available in YAML view)."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be\ncreated.\nThe default is: scanner-v4-db."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "The size of the persistent volume when created through the claim. If a claim was automatically created,\nthis can be used after the initial deployment to resize (grow) the volume (only supported by some\nstorage class controllers).",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:text"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class",
+                                    "description": "The name of the storage class to use for the PVC. If your cluster is not configured with a default storage\nclass, you must select a value here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:StorageClass"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of replicas and autoscaling for this component."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of replicas and autoscaling for this component."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.matcher.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.matcher.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "tls.additionalCAs",
+                                    "displayName": "Additional CAs",
+                                    "description": "Allows you to specify additional trusted Root CAs."
+                                }
+                            ]
+                        },
+                        {
+                            "name": "securedclusters.platform.stackrox.io",
+                            "version": "v1alpha1",
+                            "kind": "SecuredCluster",
+                            "displayName": "Secured Cluster",
+                            "description": "SecuredCluster is the configuration template for the secured cluster services. These include Sensor, which is\nresponsible for the connection to Central, and Collector, which performs host-level collection of process and\nnetwork events.<p>\n**Important:** Please see the _Installation Prerequisites_ on the main RHACS operator page before deploying, or\nconsult the RHACS documentation on creating cluster init bundles.",
+                            "resources": [
+                                {
+                                    "name": "",
+                                    "kind": "DaemonSet",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Deployment",
+                                    "version": "v1"
+                                }
+                            ],
+                            "statusDescriptors": [
+                                {
+                                    "path": "productVersion",
+                                    "displayName": "Product Version",
+                                    "description": "The deployed version of the product."
+                                },
+                                {
+                                    "path": "clusterName",
+                                    "displayName": "Cluster Name",
+                                    "description": "The assigned cluster name per the spec. This cannot be changed afterwards. If you need to change the\ncluster name, please delete and recreate this resource."
+                                },
+                                {
+                                    "path": "observedGeneration",
+                                    "displayName": "Observed Generation",
+                                    "description": "ObservedGeneration is the generation most recently observed by the controller."
+                                }
+                            ],
+                            "specDescriptors": [
+                                {
+                                    "path": "clusterName",
+                                    "displayName": "Cluster Name",
+                                    "description": "The unique name of this cluster, as it will be shown in the Red Hat Advanced Cluster Security UI.\nNote: Once a name is set here, you will not be able to change it again. You will need to delete\nand re-create this object in order to register a cluster with a new name."
+                                },
+                                {
+                                    "path": "centralEndpoint",
+                                    "displayName": "Central Endpoint",
+                                    "description": "The endpoint of the Red Hat Advanced Cluster Security Central instance to connect to,\nincluding the port number. If no port is specified and the endpoint contains an https://\nprotocol specification, then the port 443 is implicitly assumed.\nIf using a non-gRPC capable load balancer, use the WebSocket protocol by prefixing the endpoint\naddress with wss://.\nNote: when leaving this blank, Sensor will attempt to connect to a Central instance running in the same\nnamespace."
+                                },
+                                {
+                                    "path": "sensor",
+                                    "displayName": "Sensor Settings",
+                                    "description": "Settings for the Sensor component."
+                                },
+                                {
+                                    "path": "admissionControl",
+                                    "displayName": "Admission Control Settings",
+                                    "description": "Settings for the Admission Control component, which is necessary for preventive policy enforcement,\nand for Kubernetes event monitoring."
+                                },
+                                {
+                                    "path": "perNode",
+                                    "displayName": "Per Node Settings",
+                                    "description": "Settings for the components running on each node in the cluster (Collector and Compliance)."
+                                },
+                                {
+                                    "path": "auditLogs",
+                                    "displayName": "Kubernetes Audit Logs Ingestion Settings",
+                                    "description": "Settings relating to the ingestion of Kubernetes audit logs."
+                                },
+                                {
+                                    "path": "processBaselines",
+                                    "displayName": "Process Baselines Settings",
+                                    "description": "Settings relating to process baselines."
+                                },
+                                {
+                                    "path": "scanner",
+                                    "displayName": "Scanner Component Settings",
+                                    "description": "Settings for the Scanner component, which is responsible for vulnerability scanning of container\nimages stored in a cluster-local image repository."
+                                },
+                                {
+                                    "path": "scannerV4",
+                                    "displayName": "Scanner V4 Component Settings",
+                                    "description": "Settings for the Scanner V4 components, which can run in addition to the previously existing Scanner components"
+                                },
+                                {
+                                    "path": "tls",
+                                    "displayName": "TLS",
+                                    "description": "Settings related to Transport Layer Security, such as Certificate Authorities."
+                                },
+                                {
+                                    "path": "imagePullSecrets",
+                                    "displayName": "Image Pull Secrets",
+                                    "description": "Additional image pull secrets to be taken into account for pulling images.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "customize",
+                                    "displayName": "Customizations",
+                                    "description": "Customizations to apply on all Secured Cluster Services components.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "overlays",
+                                    "displayName": "Overlays",
+                                    "description": "Overlays",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Monitoring configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "registryOverride",
+                                    "displayName": "Custom Default Image Registry",
+                                    "description": "Set this parameter to override the default registry in images. For example, nginx:latest -> <registry override>/library/nginx:latest",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "network",
+                                    "displayName": "Network",
+                                    "description": "Network configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "processIndicators",
+                                    "displayName": "ProcessIndicators",
+                                    "description": "Per-namespace filtering configuration for process indicators.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "misc",
+                                    "displayName": "Miscellaneous",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nMiscellaneous settings.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.enforcement",
+                                    "displayName": "Enforcement",
+                                    "description": "Set to Disabled to disable policy enforcement for the admission controller. This is not recommended.\nOn upgrades to 4.9 from previous releases, defaults to Enabled only if at least one of listenOnCreates or listenOnUpdates is true.\nOn new deployments starting with version 4.9, the default is: Enabled."
+                                },
+                                {
+                                    "path": "admissionControl.bypass",
+                                    "displayName": "Bypass",
+                                    "description": "Enables teams to bypass admission control in a monitored manner in the event of an emergency.\nThe default is: BreakGlassAnnotation."
+                                },
+                                {
+                                    "path": "admissionControl.failurePolicy",
+                                    "displayName": "Failure Policy",
+                                    "description": "If set to \"Fail\", the admission controller's webhooks are configured to fail-closed in case admission controller\nfails to respond in time. A failure policy \"Ignore\" configures the webhooks to fail-open.\nThe default is: Ignore."
+                                },
+                                {
+                                    "path": "admissionControl.replicas",
+                                    "displayName": "Replicas",
+                                    "description": "The number of replicas of the admission control pod.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "admissionControl.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "admissionControl.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "admissionControl.contactImageScanners",
+                                    "displayName": "Contact Image Scanners",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.listenOnCreates",
+                                    "displayName": "Listen On Creates",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.listenOnEvents",
+                                    "displayName": "Listen On Events",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.listenOnUpdates",
+                                    "displayName": "Listen On Updates",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.timeoutSeconds",
+                                    "displayName": "Timeout Seconds",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "auditLogs.collection",
+                                    "displayName": "Collection",
+                                    "description": "Whether collection of Kubernetes audit logs should be enabled or disabled. Currently, this is only\nsupported on OpenShift 4, and trying to enable it on non-OpenShift 4 clusters will result in an error.\nUse the 'Auto' setting to enable it on compatible environments, and disable it elsewhere.\nThe default is: Auto."
+                                },
+                                {
+                                    "path": "customize.labels",
+                                    "displayName": "Labels",
+                                    "description": "Custom labels to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.annotations",
+                                    "displayName": "Annotations",
+                                    "description": "Custom annotations to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.envVars",
+                                    "displayName": "Environment Variables",
+                                    "description": "Custom environment variables to set on managed pods' containers."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults",
+                                    "displayName": "Deployment Defaults",
+                                    "description": "Global nodeSelector and tolerations for Deployment-based components. DaemonSets (Collector) are not affected.\nComponent-level nodeSelector and tolerations settings override these defaults on a field-by-field basis."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults.pinToNodes",
+                                    "displayName": "Pin To Nodes",
+                                    "description": "Pin all Deployment-based components to specific node types. This is a convenience setting\nthat automatically configures both nodeSelector and tolerations with predefined values.\nUse this for common scenarios like running on OpenShift infrastructure nodes.\nFor custom node selection, use the explicit nodeSelector and tolerations fields instead.\nCannot be used together with nodeSelector or tolerations fields.\nThe default is: None."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "Default nodeSelector applied to all Deployment-based components. Use this for custom node\nselection criteria.\nCannot be used together with pinToNodes."
+                                },
+                                {
+                                    "path": "customize.deploymentDefaults.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "Default tolerations applied to all Deployment-based components. Use this when your target\nnodes have custom taints that pods must tolerate.\nCannot be used together with pinToNodes."
+                                },
+                                {
+                                    "path": "imagePullSecrets[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "misc.createSCCs",
+                                    "displayName": "Create SecurityContextConstraints for Operand",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nSet this to true to have the operator create SecurityContextConstraints (SCCs) for the operands. This\nisn't usually needed, and may interfere with other workloads.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring.openshift.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: true.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+                                    ]
+                                },
+                                {
+                                    "path": "network.policies",
+                                    "displayName": "Network Policies",
+                                    "description": "To provide security at the network level, the ACS Operator creates NetworkPolicy resources by default. If you want to manage your own NetworkPolicy objects then set this to \"Disabled\".\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "overlays[0].apiVersion",
+                                    "displayName": "API Version",
+                                    "description": "Resource API version."
+                                },
+                                {
+                                    "path": "overlays[0].kind",
+                                    "displayName": "Kind",
+                                    "description": "Resource kind."
+                                },
+                                {
+                                    "path": "overlays[0].name",
+                                    "displayName": "Name",
+                                    "description": "Name of resource."
+                                },
+                                {
+                                    "path": "overlays[0].optional",
+                                    "displayName": "Optional",
+                                    "description": "Optional marks the overlay as optional.\nWhen Optional is true, and the specified resource does not exist in the output manifests, the overlay will be skipped, and a warning will be logged.\nWhen Optional is false, and the specified resource does not exist in the output manifests, an error will be thrown."
+                                },
+                                {
+                                    "path": "overlays[0].patches",
+                                    "displayName": "Patches",
+                                    "description": "List of patches to apply to resource."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].path",
+                                    "displayName": "Path",
+                                    "description": "Path of the form a.[key1:value1].b.[:value2]\nWhere [key1:value1] is a selector for a key-value pair to identify a list element and [:value] is a value\nselector to identify a list element in a leaf list.\nAll path intermediate nodes must exist."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].value",
+                                    "displayName": "Value",
+                                    "description": "Value to add, delete or replace.\nFor add, the path should be a new leaf.\nFor delete, value should be unset.\nFor replace, path should reference an existing node.\nAll values are strings but are converted into appropriate type based on schema."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].verbatim",
+                                    "displayName": "Verbatim",
+                                    "description": "Verbatim value to add, delete or replace.\nSame as Value, but the content is not interpreted as YAML and is treated as a literal string instead.\nAt least one of Value and Verbatim must be empty."
+                                },
+                                {
+                                    "path": "perNode.collector",
+                                    "displayName": "Collector Settings",
+                                    "description": "Settings for the Collector container, which is responsible for collecting process and networking\nactivity at the host level."
+                                },
+                                {
+                                    "path": "perNode.compliance",
+                                    "displayName": "Compliance Settings",
+                                    "description": "Settings for the Compliance container, which is responsible for checking host-level configurations."
+                                },
+                                {
+                                    "path": "perNode.nodeInventory",
+                                    "displayName": "Node Scanning Settings",
+                                    "description": "Settings for the Node-Inventory container, which is responsible for scanning the Nodes' filesystem."
+                                },
+                                {
+                                    "path": "perNode.fileActivityMonitoring",
+                                    "displayName": "File Activity Monitoring Settings",
+                                    "description": "Settings for the File Activity Monitoring container, which is responsible for monitoring file operations on the Node."
+                                },
+                                {
+                                    "path": "perNode.taintToleration",
+                                    "displayName": "Taint Toleration",
+                                    "description": "To ensure comprehensive monitoring of your cluster activity, Red Hat Advanced Cluster Security\nwill run services on every node in the cluster, including tainted nodes by default. If you do\nnot want this behavior, please select 'AvoidTaints' here.\nThe default is: TolerateTaints."
+                                },
+                                {
+                                    "path": "perNode.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "perNode.collector.collection",
+                                    "displayName": "Collection",
+                                    "description": "The method for system-level data collection. CORE_BPF is recommended.\nIf you select \"NoCollection\", you will not be able to see any information about network activity\nand process executions. The remaining settings in this section will not have any effect.\nThe value is a subject of conversion by the operator if needed, e.g. to\nremove deprecated methods.\nThe default is: CORE_BPF.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:select:CORE_BPF",
+                                        "urn:alm:descriptor:com.tectonic.ui:select:NoCollection"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.collector.imageFlavor",
+                                    "displayName": "Image Flavor",
+                                    "description": "Obsolete field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.collector.forceCollection",
+                                    "displayName": "Force Collection",
+                                    "description": "Obsolete field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.collector.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.compliance.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.fileActivityMonitoring.mode",
+                                    "displayName": "Mode",
+                                    "description": "Specifies whether File Activity Monitoring is deployed.\nThe default is: Disabled.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Enabled",
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Disabled"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.fileActivityMonitoring.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.nodeInventory.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "processBaselines.autoLock",
+                                    "displayName": "Auto Lock",
+                                    "description": "Should process baselines be automatically locked when the observation period (1 hour by default) ends.\nThe default is: Disabled.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Enabled",
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Disabled"
+                                    ]
+                                },
+                                {
+                                    "path": "processIndicators.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Whether to persist individual process indicators.\nThe default is: Enabled.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Enabled",
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Disabled"
+                                    ]
+                                },
+                                {
+                                    "path": "processIndicators.excludeOpenshiftNs",
+                                    "displayName": "Exclude Openshift Ns",
+                                    "description": "Whether to persist process indicators originating from openshift namespaces.\nThe default is: Disabled.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Enabled",
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Disabled"
+                                    ]
+                                },
+                                {
+                                    "path": "processIndicators.excludeNamespaceRegex",
+                                    "displayName": "Exclude Namespace Regex",
+                                    "description": "A regex specifying namespaces whose process indicators should not be persisted."
+                                },
+                                {
+                                    "path": "scanner.scannerComponent",
+                                    "displayName": "Scanner Component",
+                                    "description": "If you do not want to deploy the Red Hat Advanced Cluster Security Scanner, you can disable it here\n(not recommended).\nIf you do so, all the settings in this section will have no effect.\nThe default is: AutoSense."
+                                },
+                                {
+                                    "path": "scanner.analyzer",
+                                    "displayName": "Analyzer",
+                                    "description": "Settings pertaining to the analyzer deployment, such as for autoscaling."
+                                },
+                                {
+                                    "path": "scanner.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the database used by the Red Hat Advanced Cluster Security Scanner."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of analyzer replicas and autoscaling."
+                                },
+                                {
+                                    "path": "scanner.analyzer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scanner.analyzer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scanner.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.scannerComponent",
+                                    "displayName": "Scanner V4 component",
+                                    "description": "If you want to enable the Scanner V4 component set this to \"AutoSense\".\nA value of \"AutoSense\" means that Scanner V4 should be installed,\nunless there is a Central resource in the same namespace.\nIn that case typically a central Scanner V4 will be deployed as a component of Central.\nA value of \"Disabled\" means that Scanner V4 should not be installed.\nIf this field is not specified or set to \"Default\", the following defaulting takes place:\n* for upgrades to 4.8 from previous releases, the default is: Disabled;\n* for new installations starting with ACS 4.8, the default is: AutoSense."
+                                },
+                                {
+                                    "path": "scannerV4.indexer",
+                                    "displayName": "Indexer",
+                                    "description": "Settings pertaining to the indexer deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:AutoSense"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the DB deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:AutoSense"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Scanner V4. The monitoring endpoint\nallows other services to collect metrics from Scanner V4, provided in\nPrometheus compatible format.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:AutoSense"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Configures how Scanner V4 should store its persistent data.\nYou can use a persistent volume claim (the recommended default), a host path,\nor an emptyDir volume if Scanner V4 is running on a secured cluster without default StorageClass."
+                                },
+                                {
+                                    "path": "scannerV4.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scannerV4.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent volume claim",
+                                    "description": "Uses a Kubernetes persistent volume claim (PVC) to manage the storage location of persistent data.\nRecommended for most users."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath",
+                                    "displayName": "Host path",
+                                    "description": "Stores persistent data in a directory on the host. This is not recommended, and should only\nbe used together with a node selector (only available in YAML view)."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be\ncreated.\nThe default is: scanner-v4-db."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "The size of the persistent volume when created through the claim. If a claim was automatically created,\nthis can be used after the initial deployment to resize (grow) the volume (only supported by some\nstorage class controllers).",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:text"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class",
+                                    "description": "The name of the storage class to use for the PVC. If your cluster is not configured with a default storage\nclass, you must select a value here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:StorageClass"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of replicas and autoscaling for this component."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "sensor.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "sensor.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here.\nThis setting overrides spec.customize.deploymentDefaults.nodeSelector."
+                                },
+                                {
+                                    "path": "sensor.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.\nThis setting overrides spec.customize.deploymentDefaults.tolerations.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "sensor.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "tls.additionalCAs",
+                                    "displayName": "Additional CAs",
+                                    "description": "Allows you to specify additional trusted Root CAs."
+                                }
+                            ]
+                        },
+                        {
+                            "name": "securitypolicies.config.stackrox.io",
+                            "version": "v1alpha1",
+                            "kind": "SecurityPolicy",
+                            "displayName": "Security Policy",
+                            "description": "SecurityPolicy is the schema for the policies API.",
+                            "resources": [
+                                {
+                                    "name": "",
+                                    "kind": "Deployment",
+                                    "version": "v1"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "## Why use Red Hat Advanced Cluster Security for Kubernetes?\n\nProtecting cloud-native applications requires significant changes in how we approach security—we must apply controls earlier in the application development life cycle, use the infrastructure itself to apply controls, and keep up with increasingly rapid release schedules.\n\n\nRed Hat® Advanced Cluster Security for Kubernetes, powered by StackRox technology, protects your vital applications across build, deploy, and runtime. Our software deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance. The policy engine includes hundreds of built-in controls to enforce DevOps and security best practices, industry standards such as CIS Benchmarks and National Institute of Standards Technology (NIST) guidelines, configuration management of both containers and Kubernetes, and runtime security.\n\nRed Hat Advanced Cluster Security for Kubernetes provides a Kubernetes-native architecture for container security, enabling DevOps and InfoSec teams to operationalize security.\n\n## Features and Benefits\n\n**Kubernetes-native security:**\n1. Increases protection.\n1. Eliminates blind spots, providing staff with insights into critical vulnerabilities and threat vectors.\n1. Reduces time and costs.\n1. Reduces the time and effort needed to implement security and streamlines security analysis, investigation, and remediation using the rich context Kubernetes provides.\n1. Increases scalability and portability.\n1. Provides scalability and resiliency native to Kubernetes, avoiding operational conflict and complexity that can result from out-of-band security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\nRed Hat provides the RHACS Operator by using the following update channels in the Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version and patches to the most recent version.\n  Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.\n* `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).\n\nNote that the `latest` channel is deprecated and is not updated after RHACS version 3.74. Newer versions are published to the `stable` channel.\n\n**RHACS comes with two custom resources:**\n\n1. **Central Services** - Central is a deployment required on only one cluster in your environment. Users interact with RHACS via the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. Users may select exposures for Central that best meet their environment.\n\n2. **Secured Cluster Services** - Secured cluster services are placed on each cluster you manage and report back to Central. These services allow users to enforce policies and monitor your OpenShift and Kubernetes clusters. Secured Cluster Services come as two Deployments (Sensor and Admission Controller) and one DaemonSet (Collector).\n\n**Console Plugin (Tech Preview):** RHACS provides a dynamic plugin that displays vulnerability management information in the OpenShift web console. Install a SecuredCluster to deploy the plugin. Enable the plugin by selecting *Operators* > *Installed Operators* or by modifying the console Operator configuration.\n**Important:** The Console Plugin requires OpenShift 4.19 or later.\n\n### Central Services Explained\n\n| Service                          | Deployment Type | Description     |\n| :------------------------------- | :-------------- | :-------------- |\n| Central                          | Deployment      | Users interact with Red Hat Advanced Cluster Security through the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. |\n| Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |\n| Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |\n| Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |\n\n### Secured Cluster Services Explained\n\n| Service                          | Deployment Type | Description     |\n| :------------------------------- | :-------------- | :-------------- |\n| Sensor                           | Deployment      | Sensor analyzes and monitors Kubernetes in secured clusters. |\n| Collector                        | DaemonSet       | Analyzes and monitors container activity on Kubernetes nodes.|\n| Admission Controller             | Deployment      | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle. |\n\n### Central Custom Resource\n\nCentral Services is the configuration template for RHACS Central deployment. For all customization options, please visit the RHACS documentation.\n\n### SecuredCluster Custom Resource\n\nSecuredCluster is the configuration template for the RHACS Secured Cluster services.\n\n#### Installation Prerequisites\n\nBefore deploying a SecuredCluster resource, you need to create a cluster init bundle secret.\n\n- **Through the RHACS UI:** To create a cluster init bundle secret through the RHACS UI, navigate to `Platform Configuration > Clusters`, and then click `Manage Tokens` in the top-right corner. Select `Cluster Init Bundle`, and click `Generate Bundle`. Select `Download Kubernetes secrets file`, and store the file under a name of your choice (for example, `cluster-init-secrets.yaml`).\n- **Through the `roxctl` CLI:** To create a cluster init bundle secret through the `roxctl` command-line interface, run `roxctl central init-bundles generate <name> --output-secrets <file name>`. Choose any `name` and `file name` that you like.\n\nRun `oc project` and check that it reports the correct namespace where you intend to deploy SecuredCluster. In case you want to install SecuredCluster to a different namespace, select it by running `oc project <namespace>`.\nThen, run `oc create -f init-bundle.yaml`. If you have chosen a name other than `init-bundle.yaml`, specify that file name instead.\n\n#### Required Fields\n\nThe following attributes are required to be specified. For all customization options, please visit the RHACS documentation.\n\n| Parameter          | Description     |\n| :----------------- | :-------------- |\n| `clusterName`      | The name given to this secured cluster. The cluster will appear with this name in RHACS user interface. |\n| `centralEndpoint`  | This field should specify the address of the Central endpoint, including the port number. `centralEndpoint` may be omitted if this SecuredCluster Custom Resource is in the same cluster and namespace as Central. |\n",
+                "displayName": "Advanced Cluster Security for Kubernetes",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "advanced-cluster-security",
+                    "stackrox",
+                    "security",
+                    "vulnerabilities",
+                    "compliance",
+                    "devsecops",
+                    "monitoring",
+                    "scanning",
+                    "runtime-security",
+                    "network policy",
+                    "configuration",
+                    "risk"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Red Hat Advanced Cluster Security Documentation",
+                        "url": "https://docs.openshift.com/acs/welcome/"
+                    },
+                    {
+                        "name": "DataSheet",
+                        "url": "https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet"
+                    },
+                    {
+                        "name": "Support Policy",
+                        "url": "https://access.redhat.com/node/5822721"
+                    },
+                    {
+                        "name": "Community Site",
+                        "url": "https://www.stackrox.io/"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Advanced Cluster Security product team",
+                        "email": "rhacs-pm@redhat.com"
+                    }
+                ],
+                "maturity": "alpha",
+                "minKubeVersion": "1.15.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f"
+        },
+        {
+            "name": "central_db",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel9@sha256:14695ed2cb21c382f50c43d14640a4d0c455666a29d9c66e86e64bb284bfd8d3"
+        },
+        {
+            "name": "collector",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel9@sha256:cb2ddf34b12d6de26a2a6828ef9917a80eecafaa05c775b29537b902a2bdc469"
+        },
+        {
+            "name": "fact",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-fact-rhel9@sha256:d7dbd19695c566af46b879feb999d6d618f750e0399415bbfe3f4be514289664"
+        },
+        {
+            "name": "main",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9@sha256:fc955573fa8b2a8019a64954431e97a9c2e4beb19c13b43bcd33c150b84bfcc6"
+        },
+        {
+            "name": "manager",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:18cdd2eff9f9e055e25607304c289942b390c98abf170f44e1adf91929fb1da7"
+        },
+        {
+            "name": "roxctl",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel9@sha256:21a2e8a6fedc76420a603a414e6d6ccf0ee9c5674e37a0b2e9e20d2a564b116d"
+        },
+        {
+            "name": "scanner_db",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel9@sha256:64b7b14fa104ef5cbf4e38c402b890addc94dc2d941f3ab5a3b0bb04229e215a"
+        },
+        {
+            "name": "scanner_db_slim",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel9@sha256:3104e8359454485caf3914ec068201c027bc0ca5a6b215a01744db6db7215c7f"
+        },
+        {
+            "name": "scanner",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel9@sha256:031c4e3391f62ffc27f5078f83b38698012b3ef27fdb0fcebe10094b2c0eacbe"
+        },
+        {
+            "name": "scanner_slim",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel9@sha256:cb568ce502cca51cbccaf5b6c4856a58dc292c2340054d0d202c9a8a3d9c86b6"
+        },
+        {
+            "name": "scanner_v4_db",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel9@sha256:bf9aabb284bdf67423189a0335d8ecf8bb0ed08c90fca5c6b59e23b02fc6b840"
+        },
+        {
+            "name": "scanner_v4",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel9@sha256:aea39fcebcd8fefc4215c28a2a1db44e61be4d2579671f485ae9d7c58e51dbb4"
         }
     ]
 }

--- a/catalog-csv-metadata/rhacs-operator/catalog.json
+++ b/catalog-csv-metadata/rhacs-operator/catalog.json
@@ -2559,9 +2559,9 @@
             "skipRange": ">= 4.10.0 < 4.11.0"
         },
         {
-            "name": "rhacs-operator.v4.11.1-rc.4",
+            "name": "rhacs-operator.v4.11.1",
             "replaces": "rhacs-operator.v4.11.0",
-            "skipRange": ">= 4.10.0 < 4.11.1-rc.4"
+            "skipRange": ">= 4.10.0 < 4.11.1"
         }
     ]
 }
@@ -5223,9 +5223,9 @@
             "skipRange": ">= 4.10.0 < 4.11.0"
         },
         {
-            "name": "rhacs-operator.v4.11.1-rc.4",
+            "name": "rhacs-operator.v4.11.1",
             "replaces": "rhacs-operator.v4.11.0",
-            "skipRange": ">= 4.10.0 < 4.11.1-rc.4"
+            "skipRange": ">= 4.10.0 < 4.11.1"
         }
     ]
 }
@@ -73005,9 +73005,9 @@
 }
 {
     "schema": "olm.bundle",
-    "name": "rhacs-operator.v4.11.1-rc.4",
+    "name": "rhacs-operator.v4.11.1",
     "package": "rhacs-operator",
-    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b",
+    "image": "registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:2fe25a8ac9612f29a625969bb25d24938abb298e9a9e1e79fb3aa34c6a0e5f76",
     "properties": [
         {
             "type": "olm.gvk",
@@ -73037,7 +73037,7 @@
             "type": "olm.package",
             "value": {
                 "packageName": "rhacs-operator",
-                "version": "4.11.1-rc.4"
+                "version": "4.11.1"
             }
         },
         {
@@ -73048,8 +73048,8 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "Security",
                     "console.openshift.io/plugins": "[\"advanced-cluster-security\"]",
-                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:0679553a10ca03ada6da849356215f0113c8ec616ce544b581b5faaf5bba32cc",
-                    "createdAt": "2026-07-06T12:00:18Z",
+                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:66f834ed8b4314257809d9880d3bdcc12c456aa399d97f5ec891e48cb95f95bf",
+                    "createdAt": "2026-07-06T16:41:52Z",
                     "description": "Red Hat Advanced Cluster Security (RHACS) operator provisions the services necessary to secure each of your OpenShift and Kubernetes clusters.",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -73061,7 +73061,7 @@
                     "features.operators.openshift.io/token-auth-aws": "false",
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
-                    "olm.skipRange": ">= 4.10.0 < 4.11.1-rc.4",
+                    "olm.skipRange": ">= 4.10.0 < 4.11.1",
                     "operatorframework.io/suggested-namespace": "rhacs-operator",
                     "operators.openshift.io/infrastructure-features": "[\"disconnected\", \"proxy-aware\"]",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Platform Plus\", \"Red Hat Advanced Cluster Security\"]",
@@ -74981,12 +74981,8 @@
     ],
     "relatedImages": [
         {
-            "name": "",
-            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b"
-        },
-        {
             "name": "central_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel9@sha256:b22d09b8a863d3f0bc61019202714b1839b4b1b2a835b34b45ec1724a4d44912"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel9@sha256:cd9b28d6b00c502c41492a5c945561c1dfa514bfec455c160ef33297ac2bcf7d"
         },
         {
             "name": "collector",
@@ -74998,15 +74994,19 @@
         },
         {
             "name": "main",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9@sha256:c18e8f0e804022475243811c119ef9cd2e3afa03d2326d0d6bd94d1607e51054"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9@sha256:3beb91a3c95eb65fbbc011c854022c775ffe2f55df178fbe55d94db7901c057b"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:2fe25a8ac9612f29a625969bb25d24938abb298e9a9e1e79fb3aa34c6a0e5f76"
         },
         {
             "name": "manager",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:0679553a10ca03ada6da849356215f0113c8ec616ce544b581b5faaf5bba32cc"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:66f834ed8b4314257809d9880d3bdcc12c456aa399d97f5ec891e48cb95f95bf"
         },
         {
             "name": "roxctl",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel9@sha256:c937fbe20385abd68e627c5f0dfc81517581d4d5524219b47f887844d42411dd"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel9@sha256:979f329cbe0d0dd1c41e63b471c246294780c5daf029c239ebd7d48129e75a15"
         },
         {
             "name": "scanner_db",
@@ -75026,11 +75026,11 @@
         },
         {
             "name": "scanner_v4_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel9@sha256:c6a230400b09a1a2a66e19fc9950b0f3b1f9ab5ebc245811b9f0579265fa0de5"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel9@sha256:6e33445791b4fba72f4db22bb74192103a3e8d3fe2ecec7afc782afeb4c5c5d3"
         },
         {
             "name": "scanner_v4",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel9@sha256:a37c0d0f587e35facc2aeefb0dc7908bcbb2c78f7517598dae07a5e05c91b0b9"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel9@sha256:ae54b522f95f33ff9a1a4fd5de95f9faaf13ed9dddbee2d4c3d197db1d45cef1"
         }
     ]
 }

--- a/catalog-csv-metadata/rhacs-operator/catalog.json
+++ b/catalog-csv-metadata/rhacs-operator/catalog.json
@@ -2559,9 +2559,9 @@
             "skipRange": ">= 4.10.0 < 4.11.0"
         },
         {
-            "name": "rhacs-operator.v4.11.1-rc.3",
+            "name": "rhacs-operator.v4.11.1-rc.4",
             "replaces": "rhacs-operator.v4.11.0",
-            "skipRange": ">= 4.10.0 < 4.11.1-rc.3"
+            "skipRange": ">= 4.10.0 < 4.11.1-rc.4"
         }
     ]
 }
@@ -5223,9 +5223,9 @@
             "skipRange": ">= 4.10.0 < 4.11.0"
         },
         {
-            "name": "rhacs-operator.v4.11.1-rc.3",
+            "name": "rhacs-operator.v4.11.1-rc.4",
             "replaces": "rhacs-operator.v4.11.0",
-            "skipRange": ">= 4.10.0 < 4.11.1-rc.3"
+            "skipRange": ">= 4.10.0 < 4.11.1-rc.4"
         }
     ]
 }
@@ -73005,9 +73005,9 @@
 }
 {
     "schema": "olm.bundle",
-    "name": "rhacs-operator.v4.11.1-rc.3",
+    "name": "rhacs-operator.v4.11.1-rc.4",
     "package": "rhacs-operator",
-    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f",
+    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b",
     "properties": [
         {
             "type": "olm.gvk",
@@ -73037,7 +73037,7 @@
             "type": "olm.package",
             "value": {
                 "packageName": "rhacs-operator",
-                "version": "4.11.1-rc.3"
+                "version": "4.11.1-rc.4"
             }
         },
         {
@@ -73048,8 +73048,8 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "Security",
                     "console.openshift.io/plugins": "[\"advanced-cluster-security\"]",
-                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:18cdd2eff9f9e055e25607304c289942b390c98abf170f44e1adf91929fb1da7",
-                    "createdAt": "2026-07-03T13:59:16Z",
+                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:0679553a10ca03ada6da849356215f0113c8ec616ce544b581b5faaf5bba32cc",
+                    "createdAt": "2026-07-06T12:00:18Z",
                     "description": "Red Hat Advanced Cluster Security (RHACS) operator provisions the services necessary to secure each of your OpenShift and Kubernetes clusters.",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -73061,7 +73061,7 @@
                     "features.operators.openshift.io/token-auth-aws": "false",
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
-                    "olm.skipRange": ">= 4.10.0 < 4.11.1-rc.3",
+                    "olm.skipRange": ">= 4.10.0 < 4.11.1-rc.4",
                     "operatorframework.io/suggested-namespace": "rhacs-operator",
                     "operators.openshift.io/infrastructure-features": "[\"disconnected\", \"proxy-aware\"]",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Platform Plus\", \"Red Hat Advanced Cluster Security\"]",
@@ -74982,11 +74982,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f"
+            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b"
         },
         {
             "name": "central_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel9@sha256:14695ed2cb21c382f50c43d14640a4d0c455666a29d9c66e86e64bb284bfd8d3"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel9@sha256:b22d09b8a863d3f0bc61019202714b1839b4b1b2a835b34b45ec1724a4d44912"
         },
         {
             "name": "collector",
@@ -74998,15 +74998,15 @@
         },
         {
             "name": "main",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9@sha256:fc955573fa8b2a8019a64954431e97a9c2e4beb19c13b43bcd33c150b84bfcc6"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9@sha256:c18e8f0e804022475243811c119ef9cd2e3afa03d2326d0d6bd94d1607e51054"
         },
         {
             "name": "manager",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:18cdd2eff9f9e055e25607304c289942b390c98abf170f44e1adf91929fb1da7"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel9-operator@sha256:0679553a10ca03ada6da849356215f0113c8ec616ce544b581b5faaf5bba32cc"
         },
         {
             "name": "roxctl",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel9@sha256:21a2e8a6fedc76420a603a414e6d6ccf0ee9c5674e37a0b2e9e20d2a564b116d"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel9@sha256:c937fbe20385abd68e627c5f0dfc81517581d4d5524219b47f887844d42411dd"
         },
         {
             "name": "scanner_db",
@@ -75026,11 +75026,11 @@
         },
         {
             "name": "scanner_v4_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel9@sha256:bf9aabb284bdf67423189a0335d8ecf8bb0ed08c90fca5c6b59e23b02fc6b840"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel9@sha256:c6a230400b09a1a2a66e19fc9950b0f3b1f9ab5ebc245811b9f0579265fa0de5"
         },
         {
             "name": "scanner_v4",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel9@sha256:aea39fcebcd8fefc4215c28a2a1db44e61be4d2579671f485ae9d7c58e51dbb4"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel9@sha256:a37c0d0f587e35facc2aeefb0dc7908bcbb2c78f7517598dae07a5e05c91b0b9"
         }
     ]
 }

--- a/catalog-template.yaml
+++ b/catalog-template.yaml
@@ -2833,9 +2833,9 @@ entries:
   - name: rhacs-operator.v4.11.0
     replaces: rhacs-operator.v4.10.4
     skipRange: ">= 4.10.0 < 4.11.0"
-  - name: rhacs-operator.v4.11.1-rc.3
+  - name: rhacs-operator.v4.11.1-rc.4
     replaces: rhacs-operator.v4.11.0
-    skipRange: ">= 4.10.0 < 4.11.1-rc.3"
+    skipRange: ">= 4.10.0 < 4.11.1-rc.4"
 - schema: olm.channel
   name: stable
   package: rhacs-operator
@@ -3124,9 +3124,9 @@ entries:
   - name: rhacs-operator.v4.11.0
     replaces: rhacs-operator.v4.10.4
     skipRange: ">= 4.10.0 < 4.11.0"
-  - name: rhacs-operator.v4.11.1-rc.3
+  - name: rhacs-operator.v4.11.1-rc.4
     replaces: rhacs-operator.v4.11.0
-    skipRange: ">= 4.10.0 < 4.11.1-rc.3"
+    skipRange: ">= 4.10.0 < 4.11.1-rc.4"
 - schema: olm.deprecations
   package: rhacs-operator
   entries:
@@ -4009,4 +4009,4 @@ entries:
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:09da338721670816180c98f7c24f2fae79971487b82bcfeca750d49b369ca0a6
 - schema: olm.bundle
-  image: quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f
+  image: quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b

--- a/catalog-template.yaml
+++ b/catalog-template.yaml
@@ -2833,9 +2833,9 @@ entries:
   - name: rhacs-operator.v4.11.0
     replaces: rhacs-operator.v4.10.4
     skipRange: ">= 4.10.0 < 4.11.0"
-  - name: rhacs-operator.v4.11.1-rc.4
+  - name: rhacs-operator.v4.11.1
     replaces: rhacs-operator.v4.11.0
-    skipRange: ">= 4.10.0 < 4.11.1-rc.4"
+    skipRange: ">= 4.10.0 < 4.11.1"
 - schema: olm.channel
   name: stable
   package: rhacs-operator
@@ -3124,9 +3124,9 @@ entries:
   - name: rhacs-operator.v4.11.0
     replaces: rhacs-operator.v4.10.4
     skipRange: ">= 4.10.0 < 4.11.0"
-  - name: rhacs-operator.v4.11.1-rc.4
+  - name: rhacs-operator.v4.11.1
     replaces: rhacs-operator.v4.11.0
-    skipRange: ">= 4.10.0 < 4.11.1-rc.4"
+    skipRange: ">= 4.10.0 < 4.11.1"
 - schema: olm.deprecations
   package: rhacs-operator
   entries:
@@ -4009,4 +4009,4 @@ entries:
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:09da338721670816180c98f7c24f2fae79971487b82bcfeca750d49b369ca0a6
 - schema: olm.bundle
-  image: quay.io/rhacs-eng/release-operator-bundle@sha256:61b5f8b6442801021a2cadf481693acbb958622746391bf8a9321ea22531c96b
+  image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:2fe25a8ac9612f29a625969bb25d24938abb298e9a9e1e79fb3aa34c6a0e5f76

--- a/catalog-template.yaml
+++ b/catalog-template.yaml
@@ -2833,6 +2833,9 @@ entries:
   - name: rhacs-operator.v4.11.0
     replaces: rhacs-operator.v4.10.4
     skipRange: ">= 4.10.0 < 4.11.0"
+  - name: rhacs-operator.v4.11.1-rc.3
+    replaces: rhacs-operator.v4.11.0
+    skipRange: ">= 4.10.0 < 4.11.1-rc.3"
 - schema: olm.channel
   name: stable
   package: rhacs-operator
@@ -3121,6 +3124,9 @@ entries:
   - name: rhacs-operator.v4.11.0
     replaces: rhacs-operator.v4.10.4
     skipRange: ">= 4.10.0 < 4.11.0"
+  - name: rhacs-operator.v4.11.1-rc.3
+    replaces: rhacs-operator.v4.11.0
+    skipRange: ">= 4.10.0 < 4.11.1-rc.3"
 - schema: olm.deprecations
   package: rhacs-operator
   entries:
@@ -4002,3 +4008,5 @@ entries:
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:d96aad39e2545948e5aee4c81335acf99a2390502d2f1a9d363445536d46563b
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:09da338721670816180c98f7c24f2fae79971487b82bcfeca750d49b369ca0a6
+- schema: olm.bundle
+  image: quay.io/rhacs-eng/release-operator-bundle@sha256:6556c292f464ed510ac32b1765b2056977f7b64c01f447bdb6a1c7ff36aec05f


### PR DESCRIPTION
Adds operator-bundle image for 4.11.1 to the catalog.
- Bundle image: `registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:2fe25a8ac9612f29a625969bb25d24938abb298e9a9e1e79fb3aa34c6a0e5f76`
- Errata: https://access.redhat.com/errata/RHSA-2026:36207