### PR TITLE
Add 4.9.9 version

### DIFF
--- a/bundles.yaml
+++ b/bundles.yaml
@@ -272,6 +272,8 @@ images:
     version: 4.9.7
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:886c4e82016a653f6119c8ba3a58c0ee9884264542d38b7af5ef471d41e381ab
     version: 4.9.8
+  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a
+    version: 4.9.9-rc.1
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:1b1480e72310d6ec17c4dd4368214cd940a4da230b13304f4621c5ae560f9e9e
     version: 4.10.0
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:aa1984fa95a56acef9828b273563c3a552b192a5eb97f79daacd036d734a4d36

--- a/bundles.yaml
+++ b/bundles.yaml
@@ -272,8 +272,8 @@ images:
     version: 4.9.7
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:886c4e82016a653f6119c8ba3a58c0ee9884264542d38b7af5ef471d41e381ab
     version: 4.9.8
-  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d
-    version: 4.9.9-rc.2
+  - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:8580ba5ee1456d0def514182dbcd5b9d131e82c9e79a51ef1a44002891b1b3a0
+    version: 4.9.9
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:1b1480e72310d6ec17c4dd4368214cd940a4da230b13304f4621c5ae560f9e9e
     version: 4.10.0
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:aa1984fa95a56acef9828b273563c3a552b192a5eb97f79daacd036d734a4d36

--- a/bundles.yaml
+++ b/bundles.yaml
@@ -272,8 +272,8 @@ images:
     version: 4.9.7
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:886c4e82016a653f6119c8ba3a58c0ee9884264542d38b7af5ef471d41e381ab
     version: 4.9.8
-  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a
-    version: 4.9.9-rc.1
+  - image: quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d
+    version: 4.9.9-rc.2
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:1b1480e72310d6ec17c4dd4368214cd940a4da230b13304f4621c5ae560f9e9e
     version: 4.10.0
   - image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:aa1984fa95a56acef9828b273563c3a552b192a5eb97f79daacd036d734a4d36

--- a/catalog-csv-metadata/rhacs-operator/catalog.json
+++ b/catalog-csv-metadata/rhacs-operator/catalog.json
@@ -2053,8 +2053,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.10.0",
+            "name": "rhacs-operator.v4.9.9-rc.1",
             "replaces": "rhacs-operator.v4.9.8",
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
+        },
+        {
+            "name": "rhacs-operator.v4.10.0",
+            "replaces": "rhacs-operator.v4.9.9-rc.1",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -2529,8 +2534,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.10.0",
+            "name": "rhacs-operator.v4.9.9-rc.1",
             "replaces": "rhacs-operator.v4.9.8",
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
+        },
+        {
+            "name": "rhacs-operator.v4.10.0",
+            "replaces": "rhacs-operator.v4.9.9-rc.1",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -4740,6 +4750,11 @@
             "name": "rhacs-operator.v4.9.8",
             "replaces": "rhacs-operator.v4.9.7",
             "skipRange": ">= 4.8.0 < 4.9.8"
+        },
+        {
+            "name": "rhacs-operator.v4.9.9-rc.1",
+            "replaces": "rhacs-operator.v4.9.8",
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
         }
     ]
 }
@@ -5193,8 +5208,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.10.0",
+            "name": "rhacs-operator.v4.9.9-rc.1",
             "replaces": "rhacs-operator.v4.9.8",
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
+        },
+        {
+            "name": "rhacs-operator.v4.10.0",
+            "replaces": "rhacs-operator.v4.9.9-rc.1",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -201056,6 +201076,1903 @@
         {
             "name": "scanner_v4",
             "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:9497921bd2c4d2a344d49e9aa9c7768b71ccfcc28722a2943b1a5c905e136157"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "rhacs-operator.v4.9.9-rc.1",
+    "package": "rhacs-operator",
+    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "config.stackrox.io",
+                "kind": "SecurityPolicy",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "platform.stackrox.io",
+                "kind": "Central",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "platform.stackrox.io",
+                "kind": "SecuredCluster",
+                "version": "v1alpha1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "rhacs-operator",
+                "version": "4.9.9-rc.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"Central\",\n    \"metadata\": {\n      \"name\": \"stackrox-central-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"central\": {\n        \"exposure\": {\n          \"route\": {\n            \"enabled\": true\n          }\n        }\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"SecuredCluster\",\n    \"metadata\": {\n      \"name\": \"stackrox-secured-cluster-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"clusterName\": \"my-cluster\"\n    }\n  }\n]",
+                    "capabilities": "Seamless Upgrades",
+                    "categories": "Security",
+                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:836562df3fef91f737644423fb17ba159f72b4a6fee90ff80acdbe672c34f3b5",
+                    "createdAt": "2026-07-02T07:43:26.510076+00:00",
+                    "description": "Red Hat Advanced Cluster Security (RHACS) operator provisions the services necessary to secure each of your OpenShift and Kubernetes clusters.",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "true",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "olm.skipRange": ">= 4.8.0 < 4.9.9-rc.1",
+                    "operatorframework.io/suggested-namespace": "rhacs-operator",
+                    "operators.openshift.io/infrastructure-features": "[\"disconnected\", \"proxy-aware\"]",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Platform Plus\", \"Red Hat Advanced Cluster Security\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-unknown",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4",
+                    "support": "Red Hat"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "centrals.platform.stackrox.io",
+                            "version": "v1alpha1",
+                            "kind": "Central",
+                            "displayName": "Central",
+                            "description": "Central is the configuration template for the central services. This includes the API server, persistent storage,\nand the web UI, as well as the image scanner.",
+                            "resources": [
+                                {
+                                    "name": "",
+                                    "kind": "Deployment",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Route",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Secret",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Service",
+                                    "version": "v1"
+                                }
+                            ],
+                            "statusDescriptors": [
+                                {
+                                    "path": "central.adminPassword.info",
+                                    "displayName": "Admin Credentials Info",
+                                    "description": "Info stores information on how to obtain the admin password."
+                                },
+                                {
+                                    "path": "productVersion",
+                                    "displayName": "Product Version",
+                                    "description": "The deployed version of the product."
+                                },
+                                {
+                                    "path": "central",
+                                    "displayName": "Central"
+                                },
+                                {
+                                    "path": "central.adminPassword.adminPasswordSecretReference",
+                                    "displayName": "Admin Password Secret Reference",
+                                    "description": "AdminPasswordSecretReference contains reference for the admin password",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                }
+                            ],
+                            "specDescriptors": [
+                                {
+                                    "path": "central",
+                                    "displayName": "Central Component Settings",
+                                    "description": "Settings for the Central component, which is responsible for all user interaction."
+                                },
+                                {
+                                    "path": "scanner",
+                                    "displayName": "Scanner Component Settings",
+                                    "description": "Settings for the Scanner component, which is responsible for vulnerability scanning of container\nimages."
+                                },
+                                {
+                                    "path": "scannerV4",
+                                    "displayName": "Scanner V4 Component Settings",
+                                    "description": "Settings for the Scanner V4 component, which can run in addition to the previously existing Scanner components"
+                                },
+                                {
+                                    "path": "egress",
+                                    "displayName": "Egress",
+                                    "description": "Settings related to outgoing network traffic."
+                                },
+                                {
+                                    "path": "tls",
+                                    "displayName": "TLS",
+                                    "description": "Settings related to Transport Layer Security, such as Certificate Authorities."
+                                },
+                                {
+                                    "path": "imagePullSecrets",
+                                    "displayName": "Image Pull Secrets",
+                                    "description": "Additional image pull secrets to be taken into account for pulling images.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "customize",
+                                    "displayName": "Customizations",
+                                    "description": "Customizations to apply on all Central Services components.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "overlays",
+                                    "displayName": "Overlays",
+                                    "description": "Overlays",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Monitoring configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "network",
+                                    "displayName": "Network",
+                                    "description": "Network configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "configAsCode",
+                                    "displayName": "Config-as-Code",
+                                    "description": "Config-as-Code configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "misc",
+                                    "displayName": "Miscellaneous",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nMiscellaneous settings.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.adminPasswordSecret",
+                                    "displayName": "Administrator Password",
+                                    "description": "Specify a secret that contains the administrator password in the \"password\" data item.\nIf omitted, the operator will auto-generate a password and store it in the \"password\" item\nin the \"central-htpasswd\" secret."
+                                },
+                                {
+                                    "path": "central.exposure",
+                                    "displayName": "Exposure",
+                                    "description": "Here you can configure if you want to expose central through a node port, a load balancer, or an OpenShift\nroute."
+                                },
+                                {
+                                    "path": "central.defaultTLSSecret",
+                                    "displayName": "User-facing TLS certificate secret",
+                                    "description": "By default, Central will only serve an internal TLS certificate, which means that you will\nneed to handle TLS termination at the ingress or load balancer level.\nIf you want to terminate TLS in Central and serve a custom server certificate, you can specify\na secret containing the certificate and private key here."
+                                },
+                                {
+                                    "path": "central.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Central. The monitoring endpoint\nallows other services to collect metrics from Central, provided in\nPrometheus compatible format."
+                                },
+                                {
+                                    "path": "central.db",
+                                    "displayName": "Central DB Settings",
+                                    "description": "Settings for Central DB, which is responsible for data persistence."
+                                },
+                                {
+                                    "path": "central.telemetry",
+                                    "displayName": "Telemetry",
+                                    "description": "Configures telemetry settings for Central. If enabled, Central transmits telemetry and diagnostic\ndata to a remote storage backend.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration",
+                                    "displayName": "Declarative Configuration",
+                                    "description": "Configures resources within Central in a declarative manner.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.notifierSecretsEncryption",
+                                    "displayName": "Notifier Secrets Encryption",
+                                    "description": "Configures the encryption of notifier secrets stored in the Central DB.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "central.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "central.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "central.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "central.adminPasswordGenerationDisabled",
+                                    "displayName": "Admin Password Generation Disabled",
+                                    "description": "Disable admin password generation. Do not use this for first-time installations,\nas you will have no way to perform initial setup and configuration of alternative authentication methods.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Unused field. This field exists solely for backward compatibility starting from version v4.6.0.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.adminPasswordSecret.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.passwordSecret",
+                                    "displayName": "Administrator Password",
+                                    "description": "Specify a secret that contains the password in the \"password\" data item. This can only be used when\nspecifying a connection string manually.\nWhen omitted, the operator will auto-generate a DB password and store it in the \"password\" item\nin the \"central-db-password\" secret."
+                                },
+                                {
+                                    "path": "central.db.connectionString",
+                                    "displayName": "Connection String",
+                                    "description": "Specify a connection string that corresponds to a database managed elsewhere. If set, the operator will not manage the Central DB.\nWhen using this option, you must explicitly set a password secret; automatically generating a password will not\nbe supported."
+                                },
+                                {
+                                    "path": "central.db.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Configures how Central DB should store its persistent data. You can choose between using a persistent\nvolume claim (recommended default), and a host path."
+                                },
+                                {
+                                    "path": "central.db.configOverride",
+                                    "displayName": "Config map that will override postgresql.conf and pg_hba.conf",
+                                    "description": "Config map containing postgresql.conf and pg_hba.conf that will be used if modifications need to be applied."
+                                },
+                                {
+                                    "path": "central.db.connectionPoolSize",
+                                    "displayName": "Database Connection Pool Size Settings",
+                                    "description": "Configures the database connection pool size."
+                                },
+                                {
+                                    "path": "central.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "central.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "central.db.isEnabled",
+                                    "displayName": "Is Enabled",
+                                    "description": "Obsolete field.\nThis field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.configOverride.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced config map.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:ConfigMap"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.connectionPoolSize.maxConnections",
+                                    "displayName": "Maximum Connections",
+                                    "description": "Maximum number of connections in the connection pool.\nThe default is: 90."
+                                },
+                                {
+                                    "path": "central.db.connectionPoolSize.minConnections",
+                                    "displayName": "Minimum Connections",
+                                    "description": "Minimum number of connections in the connection pool.\nThe default is: 10."
+                                },
+                                {
+                                    "path": "central.db.passwordSecret.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent volume claim",
+                                    "description": "Uses a Kubernetes persistent volume claim (PVC) to manage the storage location of persistent data.\nRecommended for most users."
+                                },
+                                {
+                                    "path": "central.db.persistence.hostPath",
+                                    "displayName": "Host path",
+                                    "description": "Stores persistent data on a directory on the host. This is not recommended, and should only\nbe used together with a node selector (only available in YAML view)."
+                                },
+                                {
+                                    "path": "central.db.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be\ncreated.\nThe default is: central-db."
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "The size of the persistent volume when created through the claim. If a claim was automatically created,\nthis can be used after the initial deployment to resize (grow) the volume (only supported by some\nstorage class controllers).",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:text"
+                                    ]
+                                },
+                                {
+                                    "path": "central.db.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class",
+                                    "description": "The name of the storage class to use for the PVC. If your cluster is not configured with a default storage\nclass, you must select a value here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:StorageClass"
+                                    ]
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.configMaps",
+                                    "displayName": "Config maps containing declarative configuration",
+                                    "description": "List of config maps containing declarative configuration."
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.secrets",
+                                    "displayName": "Secrets containing declarative configuration",
+                                    "description": "List of secrets containing declarative configuration."
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.configMaps[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced config map.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:ConfigMap"
+                                    ]
+                                },
+                                {
+                                    "path": "central.declarativeConfiguration.secrets[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.defaultTLSSecret.name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.route",
+                                    "displayName": "Route",
+                                    "description": "Expose Central through an OpenShift route."
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer",
+                                    "displayName": "Load Balancer",
+                                    "description": "Expose Central through a load balancer service."
+                                },
+                                {
+                                    "path": "central.exposure.nodePort",
+                                    "displayName": "Node Port",
+                                    "description": "Expose Central through a node port."
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer.port",
+                                    "displayName": "Port",
+                                    "description": "The default is: 443.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.exposure.loadBalancer.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.loadBalancer.ip",
+                                    "displayName": "IP",
+                                    "description": "If you have a static IP address reserved for your load balancer, you can enter it here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.exposure.loadBalancer.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.nodePort.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.nodePort.port",
+                                    "displayName": "Port",
+                                    "description": "Use this to specify an explicit node port. Most users should leave this empty.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.exposure.nodePort.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.exposure.route.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Expose Central with a passthrough route.\nThe default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.route.host",
+                                    "displayName": "Host",
+                                    "description": "Specify a custom hostname for the Central route.\nIf unspecified, an appropriate default value will be automatically chosen by the OpenShift route operator."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt",
+                                    "displayName": "Re-Encrypt Route",
+                                    "description": "Set up a Central route with reencrypt TLS termination.\nFor reencrypt routes, the request is terminated on the OpenShift router with a custom certificate.\nThe request is then reencrypted by the OpenShift router and sent to Central.\n[user] --TLS--> [OpenShift router] --TLS--> [Central]"
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Expose Central with a reencrypt route.\nShould not be used for sensor communication.\nThe default is: false."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.host",
+                                    "displayName": "Host",
+                                    "description": "Specify a custom hostname for the Central reencrypt route.\nIf unspecified, an appropriate default value will be automatically chosen by the OpenShift route operator."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls",
+                                    "displayName": "TLS Settings",
+                                    "description": "TLS settings for exposing Central via a reencrypt Route."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.caCertificate",
+                                    "displayName": "CA Certificate",
+                                    "description": "The PEM encoded certificate chain that may be used to establish a complete chain of trust.\nDefaults to the OpenShift certificate authority."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.certificate",
+                                    "displayName": "Certificate",
+                                    "description": "The PEM encoded certificate that is served on the route. Must be a single serving\ncertificate instead of a certificate chain.\nDefaults to a certificate signed by the OpenShift certificate authority."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.destinationCACertificate",
+                                    "displayName": "Destination CA Certificate",
+                                    "description": "The CA certificate of the final destination, i.e. of Central.\nUsed by the OpenShift router for health checks on the secure connection.\nDefaults to the Central certificate authority."
+                                },
+                                {
+                                    "path": "central.exposure.route.reencrypt.tls.key",
+                                    "displayName": "Private Key",
+                                    "description": "The PEM encoded private key of the certificate that is served on the route.\nDefaults to a certificate signed by the OpenShift certificate authority."
+                                },
+                                {
+                                    "path": "central.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "central.notifierSecretsEncryption.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Enables the encryption of notifier secrets stored in the Central DB.\nThe default is: false."
+                                },
+                                {
+                                    "path": "central.persistence.hostPath",
+                                    "displayName": "Host Path",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent Volume Claim",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class Name",
+                                    "description": "Obsolete unused field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "central.telemetry.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "Specifies if Telemetry is enabled.\nThe default is: true.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+                                    ]
+                                },
+                                {
+                                    "path": "central.telemetry.storage",
+                                    "displayName": "Storage",
+                                    "description": "Defines the telemetry storage backend for Central.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:central.telemetry.enabled:true"
+                                    ]
+                                },
+                                {
+                                    "path": "central.telemetry.storage.endpoint",
+                                    "displayName": "Endpoint",
+                                    "description": "Storage API endpoint."
+                                },
+                                {
+                                    "path": "central.telemetry.storage.key",
+                                    "displayName": "Key",
+                                    "description": "Storage API key. If not set, telemetry is disabled."
+                                },
+                                {
+                                    "path": "configAsCode.configAsCodeComponent",
+                                    "displayName": "Config as Code component",
+                                    "description": "If you want to deploy the Config as Code component, set this to \"Enabled\"\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "customize.labels",
+                                    "displayName": "Labels",
+                                    "description": "Custom labels to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.annotations",
+                                    "displayName": "Annotations",
+                                    "description": "Custom annotations to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.envVars",
+                                    "displayName": "Environment Variables",
+                                    "description": "Custom environment variables to set on managed pods' containers."
+                                },
+                                {
+                                    "path": "egress.connectivityPolicy",
+                                    "displayName": "Connectivity Policy",
+                                    "description": "Configures whether Red Hat Advanced Cluster Security should run in online or offline (disconnected) mode.\nIn offline mode, automatic updates of vulnerability definitions and kernel modules are disabled.\nThe default is: Online."
+                                },
+                                {
+                                    "path": "imagePullSecrets[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "misc.createSCCs",
+                                    "displayName": "Create SecurityContextConstraints for Operand",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nSet this to true to have the operator create SecurityContextConstraints (SCCs) for the operands. This\nisn't usually needed, and may interfere with other workloads.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring.openshift.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: true.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+                                    ]
+                                },
+                                {
+                                    "path": "network.policies",
+                                    "displayName": "Network Policies",
+                                    "description": "To provide security at the network level the ACS Operator creates NetworkPolicy resources by default. If you want to manage your own NetworkPolicy objects then set this to \"Disabled\".\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "overlays[0].apiVersion",
+                                    "displayName": "API Version",
+                                    "description": "Resource API version."
+                                },
+                                {
+                                    "path": "overlays[0].kind",
+                                    "displayName": "Kind",
+                                    "description": "Resource kind."
+                                },
+                                {
+                                    "path": "overlays[0].name",
+                                    "displayName": "Name",
+                                    "description": "Name of resource."
+                                },
+                                {
+                                    "path": "overlays[0].optional",
+                                    "displayName": "Optional",
+                                    "description": "Optional marks the overlay as optional.\nWhen Optional is true, and the specified resource does not exist in the output manifests, the overlay will be skipped, and a warning will be logged.\nWhen Optional is false, and the specified resource does not exist in the output manifests, an error will be thrown."
+                                },
+                                {
+                                    "path": "overlays[0].patches",
+                                    "displayName": "Patches",
+                                    "description": "List of patches to apply to resource."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].path",
+                                    "displayName": "Path",
+                                    "description": "Path of the form a.[key1:value1].b.[:value2]\nWhere [key1:value1] is a selector for a key-value pair to identify a list element and [:value] is a value\nselector to identify a list element in a leaf list.\nAll path intermediate nodes must exist."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].value",
+                                    "displayName": "Value",
+                                    "description": "Value to add, delete or replace.\nFor add, the path should be a new leaf.\nFor delete, value should be unset.\nFor replace, path should reference an existing node.\nAll values are strings but are converted into appropriate type based on schema."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].verbatim",
+                                    "displayName": "Verbatim",
+                                    "description": "Verbatim value to add, delete or replace.\nSame as Value, however the content is not interpreted as YAML, but treated as literal string instead.\nAt least one of Value and Verbatim must be empty."
+                                },
+                                {
+                                    "path": "scanner.scannerComponent",
+                                    "displayName": "Scanner Component",
+                                    "description": "If you do not want to deploy the Red Hat Advanced Cluster Security Scanner, you can disable it here\n(not recommended). By default, the scanner is enabled.\nIf you do so, all the settings in this section will have no effect."
+                                },
+                                {
+                                    "path": "scanner.analyzer",
+                                    "displayName": "Analyzer",
+                                    "description": "Settings pertaining to the analyzer deployment, such as for autoscaling.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the database used by the Red Hat Advanced Cluster Security Scanner.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Scanner. The monitoring endpoint\nallows other services to collect metrics from Scanner, provided in\nPrometheus compatible format."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of analyzer replicas and autoscaling."
+                                },
+                                {
+                                    "path": "scanner.analyzer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scanner.analyzer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scanner.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scanner.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "scannerV4.scannerComponent",
+                                    "displayName": "Scanner V4 component",
+                                    "description": "Can be specified as \"Enabled\" or \"Disabled\".\nIf this field is not specified, the following defaulting takes place:\n* for new installations, Scanner V4 is enabled starting with ACS 4.8;\n* for upgrades to 4.8 from previous releases, Scanner V4 is disabled."
+                                },
+                                {
+                                    "path": "scannerV4.indexer",
+                                    "displayName": "Indexer",
+                                    "description": "Settings pertaining to the indexer deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher",
+                                    "displayName": "Matcher",
+                                    "description": "Settings pertaining to the matcher deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the DB deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Scanner V4. The monitoring endpoint\nallows other services to collect metrics from Scanner V4, provided in\nPrometheus compatible format.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Configures how Scanner V4 should store its persistent data.\nYou can use a persistent volume claim (the recommended default), a host path,\nor an emptyDir volume if Scanner V4 is running on a secured cluster without default StorageClass."
+                                },
+                                {
+                                    "path": "scannerV4.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scannerV4.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent volume claim",
+                                    "description": "Uses a Kubernetes persistent volume claim (PVC) to manage the storage location of persistent data.\nRecommended for most users."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath",
+                                    "displayName": "Host path",
+                                    "description": "Stores persistent data on a directory on the host. This is not recommended, and should only\nbe used together with a node selector (only available in YAML view)."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be\ncreated.\nThe default is: scanner-v4-db."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "The size of the persistent volume when created through the claim. If a claim was automatically created,\nthis can be used after the initial deployment to resize (grow) the volume (only supported by some\nstorage class controllers).",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:text"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class",
+                                    "description": "The name of the storage class to use for the PVC. If your cluster is not configured with a default storage\nclass, you must select a value here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:StorageClass"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of replicas and autoscaling for this component."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of replicas and autoscaling for this component."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.matcher.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.matcher.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.matcher.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "tls.additionalCAs",
+                                    "displayName": "Additional CAs",
+                                    "description": "Allows you to specify additional trusted Root CAs."
+                                }
+                            ]
+                        },
+                        {
+                            "name": "securedclusters.platform.stackrox.io",
+                            "version": "v1alpha1",
+                            "kind": "SecuredCluster",
+                            "displayName": "Secured Cluster",
+                            "description": "SecuredCluster is the configuration template for the secured cluster services. These include Sensor, which is\nresponsible for the connection to Central, and Collector, which performs host-level collection of process and\nnetwork events.<p>\n**Important:** Please see the _Installation Prerequisites_ on the main RHACS operator page before deploying, or\nconsult the RHACS documentation on creating cluster init bundles.",
+                            "resources": [
+                                {
+                                    "name": "",
+                                    "kind": "DaemonSet",
+                                    "version": "v1"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Deployment",
+                                    "version": "v1"
+                                }
+                            ],
+                            "statusDescriptors": [
+                                {
+                                    "path": "productVersion",
+                                    "displayName": "Product Version",
+                                    "description": "The deployed version of the product."
+                                },
+                                {
+                                    "path": "clusterName",
+                                    "displayName": "Cluster Name",
+                                    "description": "The assigned cluster name per the spec. This cannot be changed afterwards. If you need to change the\ncluster name, please delete and recreate this resource."
+                                }
+                            ],
+                            "specDescriptors": [
+                                {
+                                    "path": "clusterName",
+                                    "displayName": "Cluster Name",
+                                    "description": "The unique name of this cluster, as it will be shown in the Red Hat Advanced Cluster Security UI.\nNote: Once a name is set here, you will not be able to change it again. You will need to delete\nand re-create this object in order to register a cluster with a new name."
+                                },
+                                {
+                                    "path": "centralEndpoint",
+                                    "displayName": "Central Endpoint",
+                                    "description": "The endpoint of the Red Hat Advanced Cluster Security Central instance to connect to,\nincluding the port number. If no port is specified and the endpoint contains an https://\nprotocol specification, then the port 443 is implicitly assumed.\nIf using a non-gRPC capable load balancer, use the WebSocket protocol by prefixing the endpoint\naddress with wss://.\nNote: when leaving this blank, Sensor will attempt to connect to a Central instance running in the same\nnamespace."
+                                },
+                                {
+                                    "path": "sensor",
+                                    "displayName": "Sensor Settings",
+                                    "description": "Settings for the Sensor component."
+                                },
+                                {
+                                    "path": "admissionControl",
+                                    "displayName": "Admission Control Settings",
+                                    "description": "Settings for the Admission Control component, which is necessary for preventive policy enforcement,\nand for Kubernetes event monitoring."
+                                },
+                                {
+                                    "path": "perNode",
+                                    "displayName": "Per Node Settings",
+                                    "description": "Settings for the components running on each node in the cluster (Collector and Compliance)."
+                                },
+                                {
+                                    "path": "auditLogs",
+                                    "displayName": "Kubernetes Audit Logs Ingestion Settings",
+                                    "description": "Settings relating to the ingestion of Kubernetes audit logs."
+                                },
+                                {
+                                    "path": "processBaselines",
+                                    "displayName": "Process Baselines Settings",
+                                    "description": "Settings relating to process baselines."
+                                },
+                                {
+                                    "path": "scanner",
+                                    "displayName": "Scanner Component Settings",
+                                    "description": "Settings for the Scanner component, which is responsible for vulnerability scanning of container\nimages stored in a cluster-local image repository."
+                                },
+                                {
+                                    "path": "scannerV4",
+                                    "displayName": "Scanner V4 Component Settings",
+                                    "description": "Settings for the Scanner V4 components, which can run in addition to the previously existing Scanner components"
+                                },
+                                {
+                                    "path": "tls",
+                                    "displayName": "TLS",
+                                    "description": "Settings related to Transport Layer Security, such as Certificate Authorities."
+                                },
+                                {
+                                    "path": "imagePullSecrets",
+                                    "displayName": "Image Pull Secrets",
+                                    "description": "Additional image pull secrets to be taken into account for pulling images.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "customize",
+                                    "displayName": "Customizations",
+                                    "description": "Customizations to apply on all Central Services components.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "overlays",
+                                    "displayName": "Overlays",
+                                    "description": "Overlays",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Monitoring configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "registryOverride",
+                                    "displayName": "Custom Default Image Registry",
+                                    "description": "Set this parameter to override the default registry in images. For example, nginx:latest -> <registry override>/library/nginx:latest",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "network",
+                                    "displayName": "Network",
+                                    "description": "Network configuration.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:advanced"
+                                    ]
+                                },
+                                {
+                                    "path": "misc",
+                                    "displayName": "Miscellaneous",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nMiscellaneous settings.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.enforcement",
+                                    "displayName": "Enforcement",
+                                    "description": "Set to Disabled to disable policy enforcement for the admission controller. This is not recommended.\nOn new deployments starting with version 4.9, defaults to Enabled.\nOn old deployments, defaults to Enabled if at least one of listenOnCreates or listenOnUpdates is true."
+                                },
+                                {
+                                    "path": "admissionControl.bypass",
+                                    "displayName": "Bypass",
+                                    "description": "Enables teams to bypass admission control in a monitored manner in the event of an emergency.\nThe default is: BreakGlassAnnotation."
+                                },
+                                {
+                                    "path": "admissionControl.failurePolicy",
+                                    "displayName": "Failure Policy",
+                                    "description": "If set to \"Fail\", the admission controller's webhooks are configured to fail-closed in case admission controller\nfails to respond in time. A failure policy \"Ignore\" configures the webhooks to fail-open.\nThe default is: Ignore."
+                                },
+                                {
+                                    "path": "admissionControl.replicas",
+                                    "displayName": "Replicas",
+                                    "description": "The number of replicas of the admission control pod.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "admissionControl.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "admissionControl.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "admissionControl.contactImageScanners",
+                                    "displayName": "Contact Image Scanners",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.listenOnCreates",
+                                    "displayName": "Listen On Creates",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.listenOnEvents",
+                                    "displayName": "Listen On Events",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.listenOnUpdates",
+                                    "displayName": "Listen On Updates",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "admissionControl.timeoutSeconds",
+                                    "displayName": "Timeout Seconds",
+                                    "description": "Deprecated field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "auditLogs.collection",
+                                    "displayName": "Collection",
+                                    "description": "Whether collection of Kubernetes audit logs should be enabled or disabled. Currently, this is only\nsupported on OpenShift 4, and trying to enable it on non-OpenShift 4 clusters will result in an error.\nUse the 'Auto' setting to enable it on compatible environments, and disable it elsewhere.\nThe default is: Auto."
+                                },
+                                {
+                                    "path": "customize.labels",
+                                    "displayName": "Labels",
+                                    "description": "Custom labels to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.annotations",
+                                    "displayName": "Annotations",
+                                    "description": "Custom annotations to set on all managed objects."
+                                },
+                                {
+                                    "path": "customize.envVars",
+                                    "displayName": "Environment Variables",
+                                    "description": "Custom environment variables to set on managed pods' containers."
+                                },
+                                {
+                                    "path": "imagePullSecrets[0].name",
+                                    "displayName": "Name",
+                                    "description": "The name of the referenced secret.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:Secret"
+                                    ]
+                                },
+                                {
+                                    "path": "misc.createSCCs",
+                                    "displayName": "Create SecurityContextConstraints for Operand",
+                                    "description": "Deprecated field. This field will be removed in a future release.\nSet this to true to have the operator create SecurityContextConstraints (SCCs) for the operands. This\nisn't usually needed, and may interfere with other workloads.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "monitoring.openshift.enabled",
+                                    "displayName": "Enabled",
+                                    "description": "The default is: true.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+                                    ]
+                                },
+                                {
+                                    "path": "network.policies",
+                                    "displayName": "Network Policies",
+                                    "description": "To provide security at the network level the ACS Operator creates NetworkPolicy resources by default. If you want to manage your own NetworkPolicy objects then set this to \"Disabled\".\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "overlays[0].apiVersion",
+                                    "displayName": "API Version",
+                                    "description": "Resource API version."
+                                },
+                                {
+                                    "path": "overlays[0].kind",
+                                    "displayName": "Kind",
+                                    "description": "Resource kind."
+                                },
+                                {
+                                    "path": "overlays[0].name",
+                                    "displayName": "Name",
+                                    "description": "Name of resource."
+                                },
+                                {
+                                    "path": "overlays[0].optional",
+                                    "displayName": "Optional",
+                                    "description": "Optional marks the overlay as optional.\nWhen Optional is true, and the specified resource does not exist in the output manifests, the overlay will be skipped, and a warning will be logged.\nWhen Optional is false, and the specified resource does not exist in the output manifests, an error will be thrown."
+                                },
+                                {
+                                    "path": "overlays[0].patches",
+                                    "displayName": "Patches",
+                                    "description": "List of patches to apply to resource."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].path",
+                                    "displayName": "Path",
+                                    "description": "Path of the form a.[key1:value1].b.[:value2]\nWhere [key1:value1] is a selector for a key-value pair to identify a list element and [:value] is a value\nselector to identify a list element in a leaf list.\nAll path intermediate nodes must exist."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].value",
+                                    "displayName": "Value",
+                                    "description": "Value to add, delete or replace.\nFor add, the path should be a new leaf.\nFor delete, value should be unset.\nFor replace, path should reference an existing node.\nAll values are strings but are converted into appropriate type based on schema."
+                                },
+                                {
+                                    "path": "overlays[0].patches[0].verbatim",
+                                    "displayName": "Verbatim",
+                                    "description": "Verbatim value to add, delete or replace.\nSame as Value, however the content is not interpreted as YAML, but treated as literal string instead.\nAt least one of Value and Verbatim must be empty."
+                                },
+                                {
+                                    "path": "perNode.collector",
+                                    "displayName": "Collector Settings",
+                                    "description": "Settings for the Collector container, which is responsible for collecting process and networking\nactivity at the host level."
+                                },
+                                {
+                                    "path": "perNode.compliance",
+                                    "displayName": "Compliance Settings",
+                                    "description": "Settings for the Compliance container, which is responsible for checking host-level configurations."
+                                },
+                                {
+                                    "path": "perNode.nodeInventory",
+                                    "displayName": "Node Scanning Settings",
+                                    "description": "Settings for the Node-Inventory container, which is responsible for scanning the Nodes' filesystem."
+                                },
+                                {
+                                    "path": "perNode.taintToleration",
+                                    "displayName": "Taint Toleration",
+                                    "description": "To ensure comprehensive monitoring of your cluster activity, Red Hat Advanced Cluster Security\nwill run services on every node in the cluster, including tainted nodes by default. If you do\nnot want this behavior, please select 'AvoidTaints' here.\nThe default is: TolerateTaints."
+                                },
+                                {
+                                    "path": "perNode.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "perNode.collector.collection",
+                                    "displayName": "Collection",
+                                    "description": "The method for system-level data collection. CORE_BPF is recommended.\nIf you select \"NoCollection\", you will not be able to see any information about network activity\nand process executions. The remaining settings in these section will not have any effect.\nThe value is a subject of conversion by the operator if needed, e.g. to\nremove deprecated methods.\nThe default is: CORE_BPF.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:select:CORE_BPF",
+                                        "urn:alm:descriptor:com.tectonic.ui:select:NoCollection"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.collector.imageFlavor",
+                                    "displayName": "Image Flavor",
+                                    "description": "Obsolete field.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.collector.forceCollection",
+                                    "displayName": "Force Collection",
+                                    "description": "Obsolete field. This field will be removed in a future release.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:hidden"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.collector.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.compliance.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "perNode.nodeInventory.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "processBaselines.autoLock",
+                                    "displayName": "Auto Lock",
+                                    "description": "Should process baselines be automatically locked when the observation period (1 hour by default) ends.\nThe default is: Disabled.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Enabled",
+                                        "urn:alm:descriptor:com.tectonic.ui:select:Disabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.scannerComponent",
+                                    "displayName": "Scanner Component",
+                                    "description": "If you do not want to deploy the Red Hat Advanced Cluster Security Scanner, you can disable it here\n(not recommended).\nIf you do so, all the settings in this section will have no effect.\nThe default is: AutoSense."
+                                },
+                                {
+                                    "path": "scanner.analyzer",
+                                    "displayName": "Analyzer",
+                                    "description": "Settings pertaining to the analyzer deployment, such as for autoscaling."
+                                },
+                                {
+                                    "path": "scanner.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the database used by the Red Hat Advanced Cluster Security Scanner."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of analyzer replicas and autoscaling."
+                                },
+                                {
+                                    "path": "scanner.analyzer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scanner.analyzer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.analyzer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scanner.analyzer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scanner.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scanner.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.scannerComponent",
+                                    "displayName": "Scanner V4 component",
+                                    "description": "If you want to enable the Scanner V4 component set this to \"AutoSense\"\nIf this field is not specified or set to \"Default\", the following defaulting takes place:\n* for new installations, Scanner V4 is enabled starting with ACS 4.8;\n* for upgrades to 4.8 from previous releases, Scanner V4 is disabled."
+                                },
+                                {
+                                    "path": "scannerV4.indexer",
+                                    "displayName": "Indexer",
+                                    "description": "Settings pertaining to the indexer deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:AutoSense"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db",
+                                    "displayName": "DB",
+                                    "description": "Settings pertaining to the DB deployment.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:AutoSense"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring",
+                                    "displayName": "Monitoring",
+                                    "description": "Configures monitoring endpoint for Scanner V4. The monitoring endpoint\nallows other services to collect metrics from Scanner V4, provided in\nPrometheus compatible format.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.scannerComponent:AutoSense"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence",
+                                    "displayName": "Persistence",
+                                    "description": "Configures how Scanner V4 should store its persistent data.\nYou can use a persistent volume claim (the recommended default), a host path,\nor an emptyDir volume if Scanner V4 is running on a secured cluster without default StorageClass."
+                                },
+                                {
+                                    "path": "scannerV4.db.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scannerV4.db.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim",
+                                    "displayName": "Persistent volume claim",
+                                    "description": "Uses a Kubernetes persistent volume claim (PVC) to manage the storage location of persistent data.\nRecommended for most users."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath",
+                                    "displayName": "Host path",
+                                    "description": "Stores persistent data on a directory on the host. This is not recommended, and should only\nbe used together with a node selector (only available in YAML view)."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.hostPath.path",
+                                    "displayName": "Path",
+                                    "description": "The path on the host running Central."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.claimName",
+                                    "displayName": "Claim Name",
+                                    "description": "The name of the PVC to manage persistent data. If no PVC with the given name exists, it will be\ncreated.\nThe default is: scanner-v4-db."
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.size",
+                                    "displayName": "Size",
+                                    "description": "The size of the persistent volume when created through the claim. If a claim was automatically created,\nthis can be used after the initial deployment to resize (grow) the volume (only supported by some\nstorage class controllers).",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:text"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.db.persistence.persistentVolumeClaim.storageClassName",
+                                    "displayName": "Storage Class",
+                                    "description": "The name of the storage class to use for the PVC. If your cluster is not configured with a default storage\nclass, you must select a value here.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:io.kubernetes:StorageClass"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling",
+                                    "displayName": "Scaling",
+                                    "description": "Controls the number of replicas and autoscaling for this component."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.autoScaling",
+                                    "displayName": "Autoscaling",
+                                    "description": "When enabled, the number of component replicas is managed dynamically based on the load, within the limits\nspecified below.\nThe default is: Enabled."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.replicas",
+                                    "displayName": "Default Replicas",
+                                    "description": "When autoscaling is disabled, the number of replicas will always be configured to match this value.\nThe default is: 3."
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.minReplicas",
+                                    "displayName": "Autoscaling Minimum Replicas",
+                                    "description": "The default is: 2.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.indexer.scaling.maxReplicas",
+                                    "displayName": "Autoscaling Maximum Replicas",
+                                    "description": "The default is: 5.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:fieldDependency:scannerV4.indexer.scaling.autoScaling:Enabled"
+                                    ]
+                                },
+                                {
+                                    "path": "scannerV4.monitoring.exposeEndpoint",
+                                    "displayName": "Expose Endpoint",
+                                    "description": "Expose the monitoring endpoint. A new service, \"monitoring\",\nwith port 9090, will be created as well as a network policy allowing\ninbound connections to the port."
+                                },
+                                {
+                                    "path": "sensor.resources",
+                                    "displayName": "Resources",
+                                    "description": "Allows overriding the default resource settings for this component. Please consult the documentation\nfor an overview of default resource requirements and a sizing guide.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+                                    ]
+                                },
+                                {
+                                    "path": "sensor.nodeSelector",
+                                    "displayName": "Node Selector",
+                                    "description": "If you want this component to only run on specific nodes, you can configure a node selector here."
+                                },
+                                {
+                                    "path": "sensor.tolerations",
+                                    "displayName": "Tolerations",
+                                    "description": "If you want this component to only run on specific nodes, you can configure tolerations of tainted nodes.",
+                                    "x-descriptors": [
+                                        "urn:alm:descriptor:com.tectonic.ui:tolerations"
+                                    ]
+                                },
+                                {
+                                    "path": "sensor.hostAliases",
+                                    "displayName": "Host Aliases",
+                                    "description": "HostAliases allows configuring additional hostnames to resolve in the pod's hosts file."
+                                },
+                                {
+                                    "path": "tls.additionalCAs",
+                                    "displayName": "Additional CAs",
+                                    "description": "Allows you to specify additional trusted Root CAs."
+                                }
+                            ]
+                        },
+                        {
+                            "name": "securitypolicies.config.stackrox.io",
+                            "version": "v1alpha1",
+                            "kind": "SecurityPolicy",
+                            "displayName": "Security Policy",
+                            "description": "SecurityPolicy is the schema for the policies API.",
+                            "resources": [
+                                {
+                                    "name": "",
+                                    "kind": "Deployment",
+                                    "version": "v1"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "## Why use Red Hat Advanced Cluster Security for Kubernetes?\n\nProtecting cloud-native applications requires significant changes in how we approach security—we must apply controls earlier in the application development life cycle, use the infrastructure itself to apply controls, and keep up with increasingly rapid release schedules.\n\n\nRed Hat® Advanced Cluster Security for Kubernetes, powered by StackRox technology, protects your vital applications across build, deploy, and runtime. Our software deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance. The policy engine includes hundreds of built-in controls to enforce DevOps and security best practices, industry standards such as CIS Benchmarks and National Institute of Standards Technology (NIST) guidelines, configuration management of both containers and Kubernetes, and runtime security.\n\nRed Hat Advanced Cluster Security for Kubernetes provides a Kubernetes-native architecture for container security, enabling DevOps and InfoSec teams to operationalize security.\n\n## Features and Benefits\n\n**Kubernetes-native security:**\n1. Increases protection.\n1. Eliminates blind spots, providing staff with insights into critical vulnerabilities and threat vectors.\n1. Reduces time and costs.\n1. Reduces the time and effort needed to implement security and streamlines security analysis, investigation, and remediation using the rich context Kubernetes provides.\n1. Increases scalability and portability.\n1. Provides scalability and resiliency native to Kubernetes, avoiding operational conflict and complexity that can result from out-of-band security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\nRed Hat provides the RHACS Operator by using the following update channels in the Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version and patches to the most recent version.\n  Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.\n* `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).\n\nNote that the `latest` channel is deprecated and is not updated after RHACS version 3.74. Newer versions are published to the `stable` channel.\n\n**RHACS comes with two custom resources:**\n\n1. **Central Services** - Central is a deployment required on only one cluster in your environment. Users interact with RHACS via the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. Users may select exposures for Central that best meet their environment.\n\n2. **Secured Cluster Services** - Secured cluster services are placed on each cluster you manage and report back to Central. These services allow users to enforce policies and monitor your OpenShift and Kubernetes clusters. Secured Cluster Services come as two Deployments (Sensor and Admission Controller) and one DaemonSet (Collector).\n\n### Central Services Explained\n\n| Service                          | Deployment Type | Description     |\n| :------------------------------- | :-------------- | :-------------- |\n| Central                          | Deployment      | Users interact with Red Hat Advanced Cluster Security through the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. |\n| Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |\n| Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |\n| Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |\n\n### Secured Cluster Services Explained\n\n| Service                          | Deployment Type | Description     |\n| :------------------------------- | :-------------- | :-------------- |\n| Sensor                           | Deployment      | Sensor analyzes and monitors Kubernetes in secured clusters. |\n| Collector                        | DaemonSet       | Analyzes and monitors container activity on Kubernetes nodes.|\n| Admission Controller             | Deployment      | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle. |\n\n### Central Custom Resource\n\nCentral Services is the configuration template for RHACS Central deployment. For all customization options, please visit the RHACS documentation.\n\n### SecuredCluster Custom Resource\n\nSecuredCluster is the configuration template for the RHACS Secured Cluster services.\n\n#### Installation Prerequisites\n\nBefore deploying a SecuredCluster resource, you need to create a cluster init bundle secret.\n\n- **Through the RHACS UI:** To create a cluster init bundle secret through the RHACS UI, navigate to `Platform Configuration > Clusters`, and then click `Manage Tokens` in the top-right corner. Select `Cluster Init Bundle`, and click `Generate Bundle`. Select `Download Kubernetes secrets file`, and store the file under a name of your choice (for example, `cluster-init-secrets.yaml`).\n- **Through the `roxctl` CLI:** To create a cluster init bundle secret through the `roxctl` command-line interface, run `roxctl central init-bundles generate <name> --output-secrets <file name>`. Choose any `name` and `file name` that you like.\n\nRun `oc project` and check that it reports the correct namespace where you intend to deploy SecuredCluster. In case you want to install SecuredCluster to a different namespace, select it by running `oc project <namespace>`.\nThen, run `oc create -f init-bundle.yaml`. If you have chosen a name other than `init-bundle.yaml`, specify that file name instead.\n\n#### Required Fields\n\nThe following attributes are required to be specified. For all customization options, please visit the RHACS documentation.\n\n| Parameter          | Description     |\n| :----------------- | :-------------- |\n| `clusterName`      | The name given to this secured cluster. The cluster will appear with this name in RHACS user interface. |\n| `centralEndpoint`  | This field should specify the address of the Central endpoint, including the port number. `centralEndpoint` may be omitted if this SecuredCluster Custom Resource is in the same cluster and namespace as Central. |\n",
+                "displayName": "Advanced Cluster Security for Kubernetes",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "advanced-cluster-security",
+                    "stackrox",
+                    "security",
+                    "vulnerabilities",
+                    "compliance",
+                    "devsecops",
+                    "monitoring",
+                    "scanning",
+                    "runtime-security",
+                    "network policy",
+                    "configuration",
+                    "risk"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Red Hat Advanced Cluster Security Documentation",
+                        "url": "https://docs.openshift.com/acs/welcome/"
+                    },
+                    {
+                        "name": "DataSheet",
+                        "url": "https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet"
+                    },
+                    {
+                        "name": "Support Policy",
+                        "url": "https://access.redhat.com/node/5822721"
+                    },
+                    {
+                        "name": "Community Site",
+                        "url": "https://www.stackrox.io/"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Advanced Cluster Security product team",
+                        "email": "rhacs-pm@redhat.com"
+                    }
+                ],
+                "maturity": "alpha",
+                "minKubeVersion": "1.15.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a"
+        },
+        {
+            "name": "central_db",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:569db6dab8410b4defcde890ea04b4820977c9e1b31aaf19783e15b9263710d3"
+        },
+        {
+            "name": "collector",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8@sha256:99d1ef22346b8fd69711e74da9788c1736594c982ad60e4021e50d98d5e0ad19"
+        },
+        {
+            "name": "main",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:85e961e6c6db7e0bc34912d13d836cffcb23e53a7759fd9a2b6f95846b092730"
+        },
+        {
+            "name": "manager",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:836562df3fef91f737644423fb17ba159f72b4a6fee90ff80acdbe672c34f3b5"
+        },
+        {
+            "name": "roxctl",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:62feddb2e313e4ecf78f3ce04d97e6f025772e6919f3125f96027a84272e4bcf"
+        },
+        {
+            "name": "scanner_db",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8@sha256:63183b4a4b8554122a603cb1eadd77961b9d566d460fa3239a51d810684085df"
+        },
+        {
+            "name": "scanner_db_slim",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-slim-rhel8@sha256:f4a14a779380440770136a5206677a87c54e3f392156835e1085b24851959ac4"
+        },
+        {
+            "name": "scanner",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8@sha256:25104e95b1ec76e8d25fb9786a10665c5125577b7cbfc35ee0e3d74a0731c9df"
+        },
+        {
+            "name": "scanner_slim",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-slim-rhel8@sha256:b6aca1ee4a48915ec1891b8dfae7a74f46dd3b792b4ad722e5dea496ffe793c7"
+        },
+        {
+            "name": "scanner_v4_db",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8@sha256:eff86014bb5b42fb6fe05a64fff9a18b2e638fa2af073e3fc5124884ac9769a2"
+        },
+        {
+            "name": "scanner_v4",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:bcc9b07ce010026363c7a84f5bc8f7a322d2550dd975f1fd5e322e6b5f6d5a93"
         }
     ]
 }

--- a/catalog-csv-metadata/rhacs-operator/catalog.json
+++ b/catalog-csv-metadata/rhacs-operator/catalog.json
@@ -2053,13 +2053,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.1",
+            "name": "rhacs-operator.v4.9.9-rc.2",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
         },
         {
             "name": "rhacs-operator.v4.10.0",
-            "replaces": "rhacs-operator.v4.9.9-rc.1",
+            "replaces": "rhacs-operator.v4.9.9-rc.2",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -2534,13 +2534,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.1",
+            "name": "rhacs-operator.v4.9.9-rc.2",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
         },
         {
             "name": "rhacs-operator.v4.10.0",
-            "replaces": "rhacs-operator.v4.9.9-rc.1",
+            "replaces": "rhacs-operator.v4.9.9-rc.2",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -4752,9 +4752,9 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.1",
+            "name": "rhacs-operator.v4.9.9-rc.2",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
         }
     ]
 }
@@ -5208,13 +5208,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.1",
+            "name": "rhacs-operator.v4.9.9-rc.2",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.1"
+            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
         },
         {
             "name": "rhacs-operator.v4.10.0",
-            "replaces": "rhacs-operator.v4.9.9-rc.1",
+            "replaces": "rhacs-operator.v4.9.9-rc.2",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -201081,9 +201081,9 @@
 }
 {
     "schema": "olm.bundle",
-    "name": "rhacs-operator.v4.9.9-rc.1",
+    "name": "rhacs-operator.v4.9.9-rc.2",
     "package": "rhacs-operator",
-    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a",
+    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d",
     "properties": [
         {
             "type": "olm.gvk",
@@ -201113,7 +201113,7 @@
             "type": "olm.package",
             "value": {
                 "packageName": "rhacs-operator",
-                "version": "4.9.9-rc.1"
+                "version": "4.9.9-rc.2"
             }
         },
         {
@@ -201123,8 +201123,8 @@
                     "alm-examples": "[\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"Central\",\n    \"metadata\": {\n      \"name\": \"stackrox-central-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"central\": {\n        \"exposure\": {\n          \"route\": {\n            \"enabled\": true\n          }\n        }\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"SecuredCluster\",\n    \"metadata\": {\n      \"name\": \"stackrox-secured-cluster-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"clusterName\": \"my-cluster\"\n    }\n  }\n]",
                     "capabilities": "Seamless Upgrades",
                     "categories": "Security",
-                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:836562df3fef91f737644423fb17ba159f72b4a6fee90ff80acdbe672c34f3b5",
-                    "createdAt": "2026-07-02T07:43:26.510076+00:00",
+                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:4f5bb1f2e73322030a4fc0be4aa709ce80def5d71f25e8ea2abca2e191574fa3",
+                    "createdAt": "2026-07-06T10:08:55.434639+00:00",
                     "description": "Red Hat Advanced Cluster Security (RHACS) operator provisions the services necessary to secure each of your OpenShift and Kubernetes clusters.",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -201136,7 +201136,7 @@
                     "features.operators.openshift.io/token-auth-aws": "false",
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
-                    "olm.skipRange": ">= 4.8.0 < 4.9.9-rc.1",
+                    "olm.skipRange": ">= 4.8.0 < 4.9.9-rc.2",
                     "operatorframework.io/suggested-namespace": "rhacs-operator",
                     "operators.openshift.io/infrastructure-features": "[\"disconnected\", \"proxy-aware\"]",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Platform Plus\", \"Red Hat Advanced Cluster Security\"]",
@@ -202928,11 +202928,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a"
+            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d"
         },
         {
             "name": "central_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:569db6dab8410b4defcde890ea04b4820977c9e1b31aaf19783e15b9263710d3"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:4858d772fb4ebc69e1cbfd869c693ce876756bbf42ab9bdfd2c169a1d377ed08"
         },
         {
             "name": "collector",
@@ -202940,15 +202940,15 @@
         },
         {
             "name": "main",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:85e961e6c6db7e0bc34912d13d836cffcb23e53a7759fd9a2b6f95846b092730"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:fc6a34c7eb4b75d1d94e5068e3dd6f2c305342995f50baefe966612186d68e2b"
         },
         {
             "name": "manager",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:836562df3fef91f737644423fb17ba159f72b4a6fee90ff80acdbe672c34f3b5"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:4f5bb1f2e73322030a4fc0be4aa709ce80def5d71f25e8ea2abca2e191574fa3"
         },
         {
             "name": "roxctl",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:62feddb2e313e4ecf78f3ce04d97e6f025772e6919f3125f96027a84272e4bcf"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:797aff9822c83a43592cd9e256e80321274ae3151806e736689f0e2a28e5bd0b"
         },
         {
             "name": "scanner_db",
@@ -202968,11 +202968,11 @@
         },
         {
             "name": "scanner_v4_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8@sha256:eff86014bb5b42fb6fe05a64fff9a18b2e638fa2af073e3fc5124884ac9769a2"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8@sha256:1fc79e2fc37df8bed5579cd307df42fbfd898cf212bc894a45b2defe16cffcd6"
         },
         {
             "name": "scanner_v4",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:bcc9b07ce010026363c7a84f5bc8f7a322d2550dd975f1fd5e322e6b5f6d5a93"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:fb54f3d277b212bcdb2d7c547c35c5adc7e90f530bf3b8f527f2f26ea381b32f"
         }
     ]
 }

--- a/catalog-csv-metadata/rhacs-operator/catalog.json
+++ b/catalog-csv-metadata/rhacs-operator/catalog.json
@@ -2053,13 +2053,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.2",
+            "name": "rhacs-operator.v4.9.9",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
+            "skipRange": ">= 4.8.0 < 4.9.9"
         },
         {
             "name": "rhacs-operator.v4.10.0",
-            "replaces": "rhacs-operator.v4.9.9-rc.2",
+            "replaces": "rhacs-operator.v4.9.9",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -2534,13 +2534,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.2",
+            "name": "rhacs-operator.v4.9.9",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
+            "skipRange": ">= 4.8.0 < 4.9.9"
         },
         {
             "name": "rhacs-operator.v4.10.0",
-            "replaces": "rhacs-operator.v4.9.9-rc.2",
+            "replaces": "rhacs-operator.v4.9.9",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -4752,9 +4752,9 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.2",
+            "name": "rhacs-operator.v4.9.9",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
+            "skipRange": ">= 4.8.0 < 4.9.9"
         }
     ]
 }
@@ -5208,13 +5208,13 @@
             "skipRange": ">= 4.8.0 < 4.9.8"
         },
         {
-            "name": "rhacs-operator.v4.9.9-rc.2",
+            "name": "rhacs-operator.v4.9.9",
             "replaces": "rhacs-operator.v4.9.8",
-            "skipRange": ">= 4.8.0 < 4.9.9-rc.2"
+            "skipRange": ">= 4.8.0 < 4.9.9"
         },
         {
             "name": "rhacs-operator.v4.10.0",
-            "replaces": "rhacs-operator.v4.9.9-rc.2",
+            "replaces": "rhacs-operator.v4.9.9",
             "skipRange": ">= 4.9.0 < 4.10.0"
         },
         {
@@ -201081,9 +201081,9 @@
 }
 {
     "schema": "olm.bundle",
-    "name": "rhacs-operator.v4.9.9-rc.2",
+    "name": "rhacs-operator.v4.9.9",
     "package": "rhacs-operator",
-    "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d",
+    "image": "registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:8580ba5ee1456d0def514182dbcd5b9d131e82c9e79a51ef1a44002891b1b3a0",
     "properties": [
         {
             "type": "olm.gvk",
@@ -201113,7 +201113,7 @@
             "type": "olm.package",
             "value": {
                 "packageName": "rhacs-operator",
-                "version": "4.9.9-rc.2"
+                "version": "4.9.9"
             }
         },
         {
@@ -201123,8 +201123,8 @@
                     "alm-examples": "[\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"Central\",\n    \"metadata\": {\n      \"name\": \"stackrox-central-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"central\": {\n        \"exposure\": {\n          \"route\": {\n            \"enabled\": true\n          }\n        }\n      }\n    }\n  },\n  {\n    \"apiVersion\": \"platform.stackrox.io/v1alpha1\",\n    \"kind\": \"SecuredCluster\",\n    \"metadata\": {\n      \"name\": \"stackrox-secured-cluster-services\",\n      \"namespace\": \"stackrox\"\n    },\n    \"spec\": {\n      \"clusterName\": \"my-cluster\"\n    }\n  }\n]",
                     "capabilities": "Seamless Upgrades",
                     "categories": "Security",
-                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:4f5bb1f2e73322030a4fc0be4aa709ce80def5d71f25e8ea2abca2e191574fa3",
-                    "createdAt": "2026-07-06T10:08:55.434639+00:00",
+                    "containerImage": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:469729524bd6fb679e58fcd82990fcaf5bad957a55e2d22afbf7ad7e7d381df8",
+                    "createdAt": "2026-07-06T18:04:32.383671+00:00",
                     "description": "Red Hat Advanced Cluster Security (RHACS) operator provisions the services necessary to secure each of your OpenShift and Kubernetes clusters.",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "false",
@@ -201136,7 +201136,7 @@
                     "features.operators.openshift.io/token-auth-aws": "false",
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
-                    "olm.skipRange": ">= 4.8.0 < 4.9.9-rc.2",
+                    "olm.skipRange": ">= 4.8.0 < 4.9.9",
                     "operatorframework.io/suggested-namespace": "rhacs-operator",
                     "operators.openshift.io/infrastructure-features": "[\"disconnected\", \"proxy-aware\"]",
                     "operators.openshift.io/valid-subscription": "[\"OpenShift Platform Plus\", \"Red Hat Advanced Cluster Security\"]",
@@ -202927,12 +202927,8 @@
     ],
     "relatedImages": [
         {
-            "name": "",
-            "image": "quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d"
-        },
-        {
             "name": "central_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:4858d772fb4ebc69e1cbfd869c693ce876756bbf42ab9bdfd2c169a1d377ed08"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:49c83818bb9c3627da5918d9a5f27254cec627dd876ea83a153403c420720ced"
         },
         {
             "name": "collector",
@@ -202940,15 +202936,19 @@
         },
         {
             "name": "main",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:fc6a34c7eb4b75d1d94e5068e3dd6f2c305342995f50baefe966612186d68e2b"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8@sha256:36b823e9cdc606724dde030112d4ef3fe94ee87147ea8dcd8036d23b65bae0d0"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:8580ba5ee1456d0def514182dbcd5b9d131e82c9e79a51ef1a44002891b1b3a0"
         },
         {
             "name": "manager",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:4f5bb1f2e73322030a4fc0be4aa709ce80def5d71f25e8ea2abca2e191574fa3"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-rhel8-operator@sha256:469729524bd6fb679e58fcd82990fcaf5bad957a55e2d22afbf7ad7e7d381df8"
         },
         {
             "name": "roxctl",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:797aff9822c83a43592cd9e256e80321274ae3151806e736689f0e2a28e5bd0b"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:f6ecde171af14496d9504f2ef8686432a3156207d1029a22cab3968acc9a94e2"
         },
         {
             "name": "scanner_db",
@@ -202968,11 +202968,11 @@
         },
         {
             "name": "scanner_v4_db",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8@sha256:1fc79e2fc37df8bed5579cd307df42fbfd898cf212bc894a45b2defe16cffcd6"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-db-rhel8@sha256:3aed9b838144bfdd4b2ae311a564cc1bfe44668265ea84aab89070d1bae8397c"
         },
         {
             "name": "scanner_v4",
-            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:fb54f3d277b212bcdb2d7c547c35c5adc7e90f530bf3b8f527f2f26ea381b32f"
+            "image": "registry.redhat.io/advanced-cluster-security/rhacs-scanner-v4-rhel8@sha256:60007bd624132b7b60fdf1f5b01c7a668f806d98788c9701e1d7e13b70d7ac83"
         }
     ]
 }

--- a/catalog-template.yaml
+++ b/catalog-template.yaml
@@ -2260,9 +2260,9 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.1
+  - name: rhacs-operator.v4.9.9-rc.2
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
+    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
 - schema: olm.channel
   name: rhacs-4.10
   package: rhacs-operator
@@ -2533,11 +2533,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.1
+  - name: rhacs-operator.v4.9.9-rc.2
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
+    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
   - name: rhacs-operator.v4.10.0
-    replaces: rhacs-operator.v4.9.9-rc.1
+    replaces: rhacs-operator.v4.9.9-rc.2
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -2821,11 +2821,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.1
+  - name: rhacs-operator.v4.9.9-rc.2
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
+    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
   - name: rhacs-operator.v4.10.0
-    replaces: rhacs-operator.v4.9.9-rc.1
+    replaces: rhacs-operator.v4.9.9-rc.2
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -3115,11 +3115,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.1
+  - name: rhacs-operator.v4.9.9-rc.2
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
+    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
   - name: rhacs-operator.v4.10.0
-    replaces: rhacs-operator.v4.9.9-rc.1
+    replaces: rhacs-operator.v4.9.9-rc.2
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -4009,7 +4009,7 @@ entries:
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:886c4e82016a653f6119c8ba3a58c0ee9884264542d38b7af5ef471d41e381ab
 - schema: olm.bundle
-  image: quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a
+  image: quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:1b1480e72310d6ec17c4dd4368214cd940a4da230b13304f4621c5ae560f9e9e
 - schema: olm.bundle

--- a/catalog-template.yaml
+++ b/catalog-template.yaml
@@ -2260,6 +2260,9 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
+  - name: rhacs-operator.v4.9.9-rc.1
+    replaces: rhacs-operator.v4.9.8
+    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
 - schema: olm.channel
   name: rhacs-4.10
   package: rhacs-operator
@@ -2530,8 +2533,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.10.0
+  - name: rhacs-operator.v4.9.9-rc.1
     replaces: rhacs-operator.v4.9.8
+    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
+  - name: rhacs-operator.v4.10.0
+    replaces: rhacs-operator.v4.9.9-rc.1
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -2815,8 +2821,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.10.0
+  - name: rhacs-operator.v4.9.9-rc.1
     replaces: rhacs-operator.v4.9.8
+    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
+  - name: rhacs-operator.v4.10.0
+    replaces: rhacs-operator.v4.9.9-rc.1
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -3106,8 +3115,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.10.0
+  - name: rhacs-operator.v4.9.9-rc.1
     replaces: rhacs-operator.v4.9.8
+    skipRange: ">= 4.8.0 < 4.9.9-rc.1"
+  - name: rhacs-operator.v4.10.0
+    replaces: rhacs-operator.v4.9.9-rc.1
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -3996,6 +4008,8 @@ entries:
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:57da592df916a6bd9dfe90b2afc9a66b1cfb0da0053e87d0c65ef5c1bdf46969
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:886c4e82016a653f6119c8ba3a58c0ee9884264542d38b7af5ef471d41e381ab
+- schema: olm.bundle
+  image: quay.io/rhacs-eng/release-operator-bundle@sha256:9fcfa05b4efc8ac45d589d9808eeed25c5c52fc3e10f88836c7dadd3d993924a
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:1b1480e72310d6ec17c4dd4368214cd940a4da230b13304f4621c5ae560f9e9e
 - schema: olm.bundle

--- a/catalog-template.yaml
+++ b/catalog-template.yaml
@@ -2260,9 +2260,9 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.2
+  - name: rhacs-operator.v4.9.9
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
+    skipRange: ">= 4.8.0 < 4.9.9"
 - schema: olm.channel
   name: rhacs-4.10
   package: rhacs-operator
@@ -2533,11 +2533,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.2
+  - name: rhacs-operator.v4.9.9
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
+    skipRange: ">= 4.8.0 < 4.9.9"
   - name: rhacs-operator.v4.10.0
-    replaces: rhacs-operator.v4.9.9-rc.2
+    replaces: rhacs-operator.v4.9.9
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -2821,11 +2821,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.2
+  - name: rhacs-operator.v4.9.9
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
+    skipRange: ">= 4.8.0 < 4.9.9"
   - name: rhacs-operator.v4.10.0
-    replaces: rhacs-operator.v4.9.9-rc.2
+    replaces: rhacs-operator.v4.9.9
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -3115,11 +3115,11 @@ entries:
   - name: rhacs-operator.v4.9.8
     replaces: rhacs-operator.v4.9.7
     skipRange: ">= 4.8.0 < 4.9.8"
-  - name: rhacs-operator.v4.9.9-rc.2
+  - name: rhacs-operator.v4.9.9
     replaces: rhacs-operator.v4.9.8
-    skipRange: ">= 4.8.0 < 4.9.9-rc.2"
+    skipRange: ">= 4.8.0 < 4.9.9"
   - name: rhacs-operator.v4.10.0
-    replaces: rhacs-operator.v4.9.9-rc.2
+    replaces: rhacs-operator.v4.9.9
     skipRange: ">= 4.9.0 < 4.10.0"
   - name: rhacs-operator.v4.10.1
     replaces: rhacs-operator.v4.10.0
@@ -4009,7 +4009,7 @@ entries:
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:886c4e82016a653f6119c8ba3a58c0ee9884264542d38b7af5ef471d41e381ab
 - schema: olm.bundle
-  image: quay.io/rhacs-eng/release-operator-bundle@sha256:3397a1eaab6a3c4ed3ba6ad83814620d4b75d1db907d305841fedfbd3936eb2d
+  image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:8580ba5ee1456d0def514182dbcd5b9d131e82c9e79a51ef1a44002891b1b3a0
 - schema: olm.bundle
   image: registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:1b1480e72310d6ec17c4dd4368214cd940a4da230b13304f4621c5ae560f9e9e
 - schema: olm.bundle


### PR DESCRIPTION
Adds operator-bundle image for 4.9.9 to the catalog.

- Bundle image: `registry.redhat.io/advanced-cluster-security/rhacs-operator-bundle@sha256:8580ba5ee1456d0def514182dbcd5b9d131e82c9e79a51ef1a44002891b1b3a0`
- Errata: https://access.redhat.com/errata/RHSA-2026:36319