### PR TITLE
ROX-35975: Setup pipeline for building OCP 5.0 operator index

### DIFF
--- a/.tekton/operator-index-ocp-v5-0-build.yaml
+++ b/.tekton/operator-index-ocp-v5-0-build.yaml
@@ -7,17 +7,17 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-comment: "/konflux-retest operator-index-ocp-v4-22-on-push"
+    pipelinesascode.tekton.dev/on-comment: "/konflux-retest operator-index-ocp-v5-0-on-push"
     # The on-push filter includes konflux/* branches which are created by Mintmaker so that CI runs for commits pushed
     # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
       (event == "pull_request" && body.action != "ready_for_review")
   labels:
-    appstudio.openshift.io/application: acs-operator-index-ocp-v4-22
-    appstudio.openshift.io/component: operator-index-ocp-v4-22
+    appstudio.openshift.io/application: acs-operator-index-ocp-v5-0
+    appstudio.openshift.io/component: operator-index-ocp-v5-0
     pipelines.appstudio.openshift.io/type: build
-  name: operator-index-ocp-v4-22-on-push
+  name: operator-index-ocp-v5-0-on-push
   namespace: rh-acs-tenant
 
 spec:
@@ -28,14 +28,14 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: base-image
-    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
+    value: registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0
   - name: output-image-tag
-    value: ocp-v4-22-{{revision}}-fast
+    value: ocp-v5-0-{{revision}}-fast
   - name: catalog-dir
     value: catalog-csv-metadata
 
   taskRunTemplate:
-    serviceAccountName: build-pipeline-operator-index-ocp-v4-22
+    serviceAccountName: build-pipeline-operator-index-ocp-v5-0
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-index-ocp-v5-0-build.yaml
+++ b/.tekton/operator-index-ocp-v5-0-build.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stackrox/operator-index?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "500"
+    pipelinesascode.tekton.dev/on-comment: "/konflux-retest operator-index-ocp-v4-22-on-push"
+    # The on-push filter includes konflux/* branches which are created by Mintmaker so that CI runs for commits pushed
+    # onto these branches even without PRs and so that Mintmaker/Renovate can automerge its updates without PRs.
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" && target_branch.matches("^(master|konflux/references/master|konflux/mintmaker/.*)$")) ||
+      (event == "pull_request" && body.action != "ready_for_review")
+  labels:
+    appstudio.openshift.io/application: acs-operator-index-ocp-v4-22
+    appstudio.openshift.io/component: operator-index-ocp-v4-22
+    pipelines.appstudio.openshift.io/type: build
+  name: operator-index-ocp-v4-22-on-push
+  namespace: rh-acs-tenant
+
+spec:
+
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: base-image
+    value: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
+  - name: output-image-tag
+    value: ocp-v4-22-{{revision}}-fast
+  - name: catalog-dir
+    value: catalog-csv-metadata
+
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-index-ocp-v4-22
+
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+
+  pipelineRef:
+    name: operator-index-pipeline


### PR DESCRIPTION
## Description

Per title.
Follows after https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/20875

## Validation

When changing the base image reference from
_registry.redhat.io/openshift**4**/ose-operator-registry-rhel**9**:v4.22_, I could pull
_registry.redhat.io/openshift**5**/ose-operator-registry-rhel**9**:v5.0_ but could not pull
_registry.redhat.io/openshift**5**/ose-operator-registry-rhel**10**:v5.0_. Therefore, I assume 5/9 is the way to go.

Will just check that the pipeline succeeds and will check the image tag. Stage release validation for later.